### PR TITLE
setup component library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Inseri Core for WordPress
 
-[![License](https://img.shields.io/github/license/inseri-swiss/inseri-core-wp)](https://github.com/inseri-swiss/inseri-core-wp/blob/main/LICENSE)
+![CI workflow](https://github.com/inseri-swiss/inseri-core-wp/actions/workflows/ci.yml/badge.svg) [![License](https://img.shields.io/github/license/inseri-swiss/inseri-core-wp)](https://github.com/inseri-swiss/inseri-core-wp/blob/main/LICENSE)
 
 ## Development
 
@@ -19,7 +19,7 @@
 - switch to project's node version `nvm use`
 - install dependencies `npm ci`
 - start wp dev environment `npx wp-env start`
-- start dev server `npx wp-env start`
+- start dev server `npm start`
 
 ## Coding Guidelines
 
@@ -28,8 +28,12 @@
 Each commit message must conform to [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/). A message must be structured as follows:
 
 ```
-<type>(<optional scope>): <description>
+<type>(<scope>): <short summary>
 ```
+
+- The `type` and `short summary` are mandatory
+- The `scope` is optional
+- The `short summary` must be in present tense
 
 example
 
@@ -37,7 +41,7 @@ example
 docs: correct spelling of README
 ```
 
-### Type
+#### Type
 
 Must be one of the following:
 
@@ -52,3 +56,24 @@ Must be one of the following:
 - **test**: Adding missing tests or correcting existing tests
 - **chore**: Other changes that don't modify src or test files
 - **revert**: Reverts a previous commit
+
+### Branch Naming
+
+A branch name should be composed as follows:
+
+```
+<type>/<description>
+```
+
+example
+
+```
+feat/add-blue-button
+```
+
+#### Recommended Types
+
+- **feat**: Adds features or general changes
+- **bugfix**: Fixes a bug
+- **release**: Maintains a specific release version
+- **wip**: unknown, when it will be completed

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
 				"@fullhuman/postcss-purgecss": "^4.1.3",
 				"@prettier/plugin-php": "^0.18.9",
 				"@types/wordpress__block-editor": "^7.0.0",
-				"@types/wordpress__data": "^6.0.1",
 				"@wordpress/element": "^4.12.0",
 				"@wordpress/env": "^4.9.0",
 				"@wordpress/i18n": "^4.14.0",
 				"@wordpress/scripts": "^23.6.0",
 				"autoprefixer": "^10.4.8",
 				"bulma": "^0.9.4",
+				"classnames": "^2.3.1",
 				"cssnano": "^5.1.12",
 				"cssnano-preset-default": "^5.2.12",
 				"eslint": "^8.21.0",
@@ -26,6 +26,8 @@
 				"fork-ts-checker-webpack-plugin": "^7.2.13",
 				"postcss-prefixer": "^2.1.3",
 				"prettier": "^2.7.1",
+				"react-aria": "^3.18.0",
+				"react-stately": "^3.16.0",
 				"typescript": "^4.7.4",
 				"webpack-remove-empty-scripts": "^0.8.1"
 			}
@@ -1906,6 +1908,75 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@formatjs/ecma402-abstract": {
+			"version": "1.11.8",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
+			"integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
+			"dependencies": {
+				"@formatjs/intl-localematcher": "0.2.28",
+				"tslib": "2.4.0"
+			}
+		},
+		"node_modules/@formatjs/ecma402-abstract/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@formatjs/fast-memoize": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.4.tgz",
+			"integrity": "sha512-9ARYoLR8AEzXvj2nYrOVHY/h1dDMDWGTnKDLXSISF1uoPakSmfcZuSqjiqZX2wRkEUimPxdwTu/agyozBtZRHA==",
+			"dependencies": {
+				"tslib": "2.4.0"
+			}
+		},
+		"node_modules/@formatjs/fast-memoize/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@formatjs/icu-messageformat-parser": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.4.tgz",
+			"integrity": "sha512-3PqMvKWV1oyok0BuiXUAHIaotdhdTJw6OICqCZbfUgKT+ZRwRWO4IlCgvXJeCITaKS5p+PY0XXKjf/vUyIpWjQ==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.11.8",
+				"@formatjs/icu-skeleton-parser": "1.3.10",
+				"tslib": "2.4.0"
+			}
+		},
+		"node_modules/@formatjs/icu-messageformat-parser/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@formatjs/icu-skeleton-parser": {
+			"version": "1.3.10",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.10.tgz",
+			"integrity": "sha512-kXJmtLDqFF5aLTf8IxdJXnhrIX1Qb4Qp3a9jqRecGDYfzOa9hMhi9U0nKyhrJJ4cXxBzptcgb+LWkyeHL6nlBQ==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.11.8",
+				"tslib": "2.4.0"
+			}
+		},
+		"node_modules/@formatjs/icu-skeleton-parser/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@formatjs/intl-localematcher": {
+			"version": "0.2.28",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
+			"integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
+			"dependencies": {
+				"tslib": "2.4.0"
+			}
+		},
+		"node_modules/@formatjs/intl-localematcher/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
 		"node_modules/@fullhuman/postcss-purgecss": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.1.3.tgz",
@@ -1956,6 +2027,39 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+		},
+		"node_modules/@internationalized/date": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.0.1.tgz",
+			"integrity": "sha512-E/3lASs4mAeJ2Z2ye6ab7eUD0bPUfTeNVTAv6IS+ne9UtMu9Uepb9A1U2Ae0hDr6WAlBuvUtrakaxEdYB9TV6Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"node_modules/@internationalized/message": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.0.9.tgz",
+			"integrity": "sha512-yHQggKWUuSvj1GznVtie4tcYq+xMrkd/lTKCFHp6gG18KbIliDw+UI7sL9+yJPGuWiR083xuLyyhzqiPbNOEww==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"intl-messageformat": "^10.1.0"
+			}
+		},
+		"node_modules/@internationalized/number": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.1.1.tgz",
+			"integrity": "sha512-dBxCQKIxvsZvW2IBt3KsqrCfaw2nV6o6a8xsloJn/hjW0ayeyhKuiiMtTwW3/WGNPP7ZRyDbtuiUEjMwif1ENQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"node_modules/@internationalized/string": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.0.0.tgz",
+			"integrity": "sha512-NUSr4u+mNu5BysXFeVWZW4kvjXylPkU/YYqaWzdNuz1eABfehFiZTEYhWAAMzI3U8DTxfqF9PM3zyhk5gcfz6w==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2"
+			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -2482,6 +2586,1299 @@
 			},
 			"peerDependencies": {
 				"prettier": "^1.15.0 || ^2.0.0"
+			}
+		},
+		"node_modules/@react-aria/breadcrumbs": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.3.0.tgz",
+			"integrity": "sha512-pQonjZeBeVgyUWEZ/Ip0d7Claal2AtUPv1zkk5PI+X0g0C58B6ouRM3ZjGwoQ1Qzs4u9nrXGkcwMWga/Zxqy0Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/link": "^3.3.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/breadcrumbs": "^3.4.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/button": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.6.0.tgz",
+			"integrity": "sha512-+I+raFN5Kw85WzgmiIEQG0JhJ+WSCWJRSCgA0Nc4Wvjkm7gQSRvhSzSZiI7HQxz43h0MgFbuX/ruRn1WKPLsLg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/calendar": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.0.1.tgz",
+			"integrity": "sha512-7EejTAq1KRO0sNKegxCMW/98hSGofBvjktgQBmZea7F6JG+otadASqqS4mdz86s86LN9mDSTUJWljdJ3L/UYTw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/calendar": "^3.0.1",
+				"@react-types/button": "^3.6.0",
+				"@react-types/calendar": "^3.0.1",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/checkbox": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.5.0.tgz",
+			"integrity": "sha512-U3SXfiVus/aF3S3v9aTPILRZBnUzHs5JJhile9CXIe1YoPam8u12s4G+aS55rrwoa3XLcnvZbPbwlShcc8bjaA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/toggle": "^3.3.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/checkbox": "^3.2.0",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/combobox": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.4.0.tgz",
+			"integrity": "sha512-XJrPXGUroSh536/+Ud4akQ9+r9wJKzJxZDIE1S2gWxf0zGqbWPtSrKk6Eg7oVEJHcWi7rETmmFZM7othiDRWaA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/listbox": "^3.6.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/menu": "^3.6.0",
+				"@react-aria/overlays": "^3.10.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/combobox": "^3.2.0",
+				"@react-stately/layout": "^3.6.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/combobox": "^3.5.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/datepicker": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.1.0.tgz",
+			"integrity": "sha512-nkidFlr+0V3c7K4KwBW4G2AkIHzKGjzZBrjduXOrVxZSXbC69vvr11SrsHUWczMjC1ozEkX1WAHBiizxLdotXQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@internationalized/number": "^3.1.1",
+				"@internationalized/string": "^3.0.0",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/spinbutton": "^3.1.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/datepicker": "^3.0.1",
+				"@react-types/button": "^3.6.0",
+				"@react-types/calendar": "^3.0.1",
+				"@react-types/datepicker": "^3.1.0",
+				"@react-types/dialog": "^3.4.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/dialog": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.3.0.tgz",
+			"integrity": "sha512-kzJLjIYIRpK+ASOpOSY56sE6l+rpmk4QvIqTjrqlynXdneGVgNVu3OxX37U73Zn53is7ivbT+TugCzHTgle0qg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-types/dialog": "^3.4.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/focus": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.7.0.tgz",
+			"integrity": "sha512-LydZSLBLEUklakM0Ogdk17F3f/Uwaj5Nl1mfcK8HhrroGT8A8XH0KjA9D6gM6JGHgxZemx0ufOgxhQZeBGQMQw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0",
+				"clsx": "^1.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/grid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.4.0.tgz",
+			"integrity": "sha512-izIig52FV+uRzRuenRZ8CNLoivpT5yXsN6414RXKNnyCWDfBrllUvJYndll0ngrBKTjd6tmqJM8Y3kja/7+A9A==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/grid": "^3.3.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/virtualizer": "^3.2.2",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/i18n": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.5.1.tgz",
+			"integrity": "sha512-PtlQ/W1PXVKzCGK86MuGuCzYBwENDBjrQ2a4ux+BBQ2Dk8ZXEARSp9JaMFuOdiloXc/p4FoxCVoB+lhu4RCScg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@internationalized/message": "^3.0.9",
+				"@internationalized/number": "^3.1.1",
+				"@internationalized/string": "^3.0.0",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/interactions": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.10.0.tgz",
+			"integrity": "sha512-Lp74VfF+EskT3IqK2MBMdJpJU48p60+YkMbgtoDF6LudNO8jw0nxcsvnimPriTSkZWINRpajG/9sIa0EIDcQKw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/label": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.4.0.tgz",
+			"integrity": "sha512-QqyZMuSdnH+7mkAbZbGtLU3NhSz2luNCeM+ZJPQ3ANegrdXsKwERSwD2/ERHAC5FGLqwlzXnPhRcYdvjafg/Ug==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/label": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/link": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.3.2.tgz",
+			"integrity": "sha512-auGW+HK7kq7iMntkMl5JzWnWufxwqpFcU4HnSA5W9HEZN8Gj+WWdY9QmAYXn0GulcuCCoDAsK64AUtsFrlrXzg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/link": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/listbox": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.6.0.tgz",
+			"integrity": "sha512-AQ7Vdn5EKBBipFkEaV5uvamPdkXhDoILdGfFj/82X5miJBOzmu+gYVZ97njVVsGn+RYi8saK2VFcKeMXHOoYVQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-types/listbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/live-announcer": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.1.1.tgz",
+			"integrity": "sha512-e7b+dRh1SUTla42vzjdbhGYkeLD7E6wIYjYaHW9zZ37rBkSqLHUhTigh3eT3k5NxFlDD/uRxTYuwaFnWQgR+4g==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"node_modules/@react-aria/menu": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.6.0.tgz",
+			"integrity": "sha512-s083I10XG/K06V7wOF+VYGgUwg6ZwlmsmLlrXyFRzCVK6LXimNNC/mOeSZet6m4R4H1svtH+US/v+/eD6pkdUQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/overlays": "^3.10.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/tree": "^3.3.2",
+				"@react-types/button": "^3.6.0",
+				"@react-types/menu": "^3.7.0",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/meter": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.3.0.tgz",
+			"integrity": "sha512-svLFhWgpi6WBtStLFI7bXk9wMrLAl/8YYoEC5oUpk3B0DXgyBXx3o8/SHqSab9nNJEepfQXLvC0PVoL6116h3A==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/progress": "^3.3.0",
+				"@react-types/meter": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/numberfield": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.3.0.tgz",
+			"integrity": "sha512-BzFiwPwS1VvAsHK3OH0Dczec+ZJ8C09pfr+KRJQMVC5+CjXoX9jImu4WA6SyyD8BKQe7dg6McQsLLryBODgvNg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/spinbutton": "^3.1.2",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/numberfield": "^3.2.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/numberfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/textfield": "^3.5.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/overlays": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.10.0.tgz",
+			"integrity": "sha512-A7aI59/o4tUAISjyyRfJz3833SLe4ZKPNoxOVUzgjfkfnCKq7YDSSEC5poxDqYD9bq/NBXK6stdgaGLXQSirNw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-aria/visually-hidden": "^3.4.0",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/progress": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.3.0.tgz",
+			"integrity": "sha512-VenJJWOErvD12RKoffQomlTc2Zl6snrTT6aoM6APApW/QORUyyI8VW6CTUM68RkoQ0q3qySjsL+7yyrd6sping==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/progress": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/radio": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.3.0.tgz",
+			"integrity": "sha512-UhPxFVYKaPI8a9bF6XOl5Q7lbgW7YlrLTHnjOhxiUWvyyOsOnseiSgF9TqSfhhsF7HNYdOt1u3Xwx3vrHniCBg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/radio": "^3.5.0",
+				"@react-types/radio": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/searchfield": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.4.0.tgz",
+			"integrity": "sha512-12NodopxqWdQYQvxuKJN9RE/qBTcVVF1OgF5589jm9iVicqaedG1QJG2aUcaNsVZUgl9xKgCSfaNNwv8tcHS1g==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/searchfield": "^3.3.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/searchfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/select": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.8.0.tgz",
+			"integrity": "sha512-9lWQ22iWvcx1DCaguwkwQXnV8izD8t0LOD3PPHaA2I2QKyKgk4c3iBYlf2zaEI3zCySZc0EhWOQOIljOgejOiA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/listbox": "^3.6.0",
+				"@react-aria/menu": "^3.6.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-aria/visually-hidden": "^3.4.0",
+				"@react-stately/select": "^3.3.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/select": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/selection": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.10.0.tgz",
+			"integrity": "sha512-VvFgNRrM0kK6aqyMTeTN+pguyvYN9Wu3viftnZyk89uo2+9hfmU7DLhz5kXkdJY9UNzn033jYGwJdWEuqRq65g==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/separator": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.2.2.tgz",
+			"integrity": "sha512-Kpd1aZllhC0V95vTRLxiMp7daAfUg8tz1cfur6HcPv1c1QMi1IgwEkUuLIhJAwfmloJ/nzorlNOVJuseiv4L4Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/slider": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.2.0.tgz",
+			"integrity": "sha512-hHlPWGjiZsn07ptuPWw/PQ8vApjis9eu7G5K/H+q8iQJHJU+BADi4WScXBy7xqJKrJ7do3htIGBzJkWycf/YYw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/radio": "^3.5.0",
+				"@react-stately/slider": "^3.2.0",
+				"@react-types/radio": "^3.2.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/slider": "^3.2.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/spinbutton": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.1.2.tgz",
+			"integrity": "sha512-z41S6S9JSTVqboQiJZGIWeElk3WPpibGeCStTehJjYuYNy9Ap6yk6cYNe6UdZ+rikYI1oTw3Ycm2PMkwZERDzw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/button": "^3.6.0",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/ssr": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.3.0.tgz",
+			"integrity": "sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/switch": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.2.2.tgz",
+			"integrity": "sha512-xE8maB2gtQEADLWh/IfW/KaQqtEOSNSHrnH/zcFa8MwCmSElMdCypqhOx6DfA3vQzGeG/qTiXklACvt5m2p30Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/toggle": "^3.3.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/switch": "^3.2.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/table": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.4.0.tgz",
+			"integrity": "sha512-a3yYKRtadGzMrOJlGy2AGf2w2baESYgM2hZnB4YupBrcKJ/91BMpAbpAMolCI02av+Tz0BtAKh0kSs7nEsiiuA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/grid": "^3.4.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/table": "^3.3.0",
+				"@react-stately/virtualizer": "^3.2.2",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/table": "^3.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/tabs": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.3.0.tgz",
+			"integrity": "sha512-X6kVqKv/r25gIDvmN+UQTzLz2ScdDeqPI6yzutTJG39YkUFzD2u0GY45tvD8vi5fe8uHVQQEUjUpF9oejHOD7Q==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/tabs": "^3.2.0",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/tabs": "^3.1.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/textfield": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.7.0.tgz",
+			"integrity": "sha512-Tarag7zRY4V1MKKnh7c8XlvUpYs99IBgEuwWmWcZw0wOQdiqh8qm7fiSJEAhYv9r66nZx/1BPpQM3zg2JnW4EQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/textfield": "^3.5.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/toggle": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.3.2.tgz",
+			"integrity": "sha512-U+npP5XtNBs+e5T1UZDw5UhG8PJwnx+p68+GTY20UMVCTHtuNyjzjmI9nI3b9oVGcJ3ZKfvQAWq2uOqBjF/W3A==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/switch": "^3.2.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/tooltip": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.3.0.tgz",
+			"integrity": "sha512-Ya5HoaSqOfF9m+OA+Y8damGn1jWrDk2hBjnjPe3J+daMn1tZndM2z8e59XzOSWPF+RWG8+aiWVCwL84Rl1r6sQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/tooltip": "^3.2.0",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/tooltip": "^3.2.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/utils": {
+			"version": "3.13.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.13.2.tgz",
+			"integrity": "sha512-VTI8tv9m/BxE/lPTNCZN1fcHuY540xm+HT1vg2ZQCryudUWvzQkHi+h0z32DhiGHhvRFIGdH/enf3psip7ZLTQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0",
+				"clsx": "^1.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/visually-hidden": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.4.0.tgz",
+			"integrity": "sha512-mRl4Vfg7F0ohf7N3RWdOQLUnXC4ApM3hsfBegsRQHDkbbrcq7MGPyCa154kIZg8Ff2cOtbgvrAlymzWmkOVZEQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0",
+				"clsx": "^1.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/calendar": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.0.1.tgz",
+			"integrity": "sha512-UBc6ZVRFxykPDt2EH7iLzax6aIrIVLtrhMs8M92iqjoLgVKs1uFPQIGYq/KzZ5nbwI7Ga43B7ZX8/TpZHTAAFw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/calendar": "^3.0.1",
+				"@react-types/datepicker": "^3.1.0",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/checkbox": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.2.0.tgz",
+			"integrity": "sha512-nVO/asz7MTF5nLJcMMq5KgNlk4npckq+7nQvEVW6pyob5r2m7Lvd+Zhl4oKT0WtTIzg31VB6yRew1czKx/SUpA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/checkbox": "^3.3.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/collections": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.4.2.tgz",
+			"integrity": "sha512-CmLVWtbX4r3QaTNdI6edtrRKIZRKPuxyD7TmVIaoZBdaOXStTP4wOgyPN1ELww9bvW0MoOaQBbUn5WAPrfifFw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/combobox": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.2.0.tgz",
+			"integrity": "sha512-77TOvsqBk5xBKc19PIAsi/w7T0lKXMxsOvSfWlOG/StF14d5TJUuhk7CJWCzSgAl3LVhuAKKq5AeZMKAfIrB3w==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/select": "^3.3.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/combobox": "^3.5.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/data": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.6.0.tgz",
+			"integrity": "sha512-psuc5nziuPWYdxIFhXEt9DBT+cuhOCyGPz8cOP5RuWFfSM4r583M0SYrsi5YXCvUwhZEFFQNbapxJFfMpAHPtw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/datepicker": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.0.1.tgz",
+			"integrity": "sha512-mUvDxL6BpC9/BIs7E4f7OeVK/OwZ+gG6X549DBopJLUyVfFrQWZw5NcuEeie28WLwzYdfmhqv5NbkdWqmhjNpA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@internationalized/string": "^3.0.0",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/datepicker": "^3.1.0",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/grid": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.3.0.tgz",
+			"integrity": "sha512-30z4Kki5QWZvR22f3UrA18eMDOcXmQFzAq5pHbRs1LvxJAaqeAD2KzCT70MCgoA5XzyiOrvIPrKTBRf48du45w==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/layout": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-3.6.0.tgz",
+			"integrity": "sha512-X77WiMImtosPDRdJKPYR0oYTKWe/g34ZrpYWxKSVZjc9N6tqcj24p1lMIq/ZRZ1qOlLv9Y41vLYtm8uk5fdaMA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/virtualizer": "^3.2.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/table": "^3.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/list": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.5.2.tgz",
+			"integrity": "sha512-Jv8xzO5oanEMAblLiUUr7uwkMTd5qyczyjxJrv8O52Lwd4GwzJ1w7KggTSZ7JG99fLZozLor3p0foVVvSI1/NA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/menu": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.4.0.tgz",
+			"integrity": "sha512-xdNS3K0PmSjpNhH/Xnskfexxyo909Jkkfux4zhP5Ivk4Vkp0eThb6v9AIomUAo163PuOnHQFen1ZmwFEs92xMw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/menu": "^3.7.0",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/numberfield": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.2.0.tgz",
+			"integrity": "sha512-NMnrRntWJ8SnU37Zc5+QVq7x+5uJAT8X7qxmU3Uka+r8RNUycWg8Z5tvrBxL41phlBb+EnK62Bha7RypZrcrYQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/number": "^3.1.1",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/numberfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/overlays": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.4.0.tgz",
+			"integrity": "sha512-jXVm1V91lWOKh73cFvE9W9JtAE8idSWEUtFlVrlBI/jh0ZOt148UlRVWgHrm7FhaUpyvOFNUyfidRmKMuB+hgw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/overlays": "^3.6.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/radio": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.5.0.tgz",
+			"integrity": "sha512-qn4+wa9sf3zZXSLrrR9rQpOII8BEQeAkvxyq/YhUQXBpQ8SoF5LobpGIZqp3n8G+Cxzjxd6/GON+lOFxWr0iXA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/radio": "^3.2.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/searchfield": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.3.0.tgz",
+			"integrity": "sha512-M7j0RiDBIZ7q48ZdTgPD7kCo+H9QkpBfCndcCzHAhTaCLkZchEEbJ9cQjvaRYRZCgTh40qzQPlL8KeEJm1NvGw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/searchfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/select": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.3.0.tgz",
+			"integrity": "sha512-amF7N8izlD8Dtja75uPdvBMme9KTwuJ6HHtPAVtoVOdSDcD7yb8GTRNhsjvfW8YPm8jkrUwkSobegqaEtRM5eQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/select": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/selection": {
+			"version": "3.10.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.10.2.tgz",
+			"integrity": "sha512-3/iw0BpShWt5ie+YpOzi4Mpa3yKOtlKQZXEc0fZt3v3m3N3fMoCr7Ovkfuz5Svy47HIIN1Pk1WkRJC+CQ4hfDw==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/slider": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.2.0.tgz",
+			"integrity": "sha512-3WdG6+qEZZz/EkO6HZZXtMT25kzdaoxeUSVD+fByb7hE3aS6eb+OAJEy6LDpN7DVTBpkGhHMdRdnTT7+mntzPQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/slider": "^3.2.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/table": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.3.0.tgz",
+			"integrity": "sha512-qhZdgyD0EyePW/U/VlJCGLBNuzo2H1hQSgfRJ7+E5QVbqDwUUQ6Safz1EQ3Jhh64IcTDqxvKL3arr8THT7UKdA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/grid": "^3.3.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/table": "^3.3.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/tabs": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.2.0.tgz",
+			"integrity": "sha512-HeICk4D0mxnqmSoxJ6FI2CRHaTANIxDrJ2UTzoK9y+mMIC+ZUzXxtANda6TQ5wTOY7xUqITCHDSzxTiaI/090g==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/tabs": "^3.1.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/toggle": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.4.0.tgz",
+			"integrity": "sha512-7kPxR2+Aze7NmpWWOQanRsQvmz7R+Sdlu+2xi0Wh5LPFg+lkXSiGY63uM2amxZcbFb0Mhy5ExlRpF53ReZjEOA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/tooltip": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.2.0.tgz",
+			"integrity": "sha512-OoO/vUPWLJG05sV2fPH5K7kt+aMBqFgxKn59LxvGzS4hCeI58WLeGeJhbEOwMyF9+GO7JtdUssVrqMeahKUrzg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/tooltip": "^3.2.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/tree": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.3.2.tgz",
+			"integrity": "sha512-goviIXFYZvWJ2FOBQdKHfLwCaFUlhyGCsbX9GB7ziZhm0Ez8iWCzEy1IWoeuPaprBlHIPv6/3XtDi4ZQ52A59g==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/utils": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.5.1.tgz",
+			"integrity": "sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/virtualizer": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-3.2.2.tgz",
+			"integrity": "sha512-I0dbohDkG+Gm750YxlAp9qy6uE3HxWRBQjrvBdswuIscaBVp/espYqMvgVwxVnQnkcIcVdKZZ/gvT8HZwkR9lg==",
+			"dependencies": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/breadcrumbs": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.4.2.tgz",
+			"integrity": "sha512-CfLsyHXL2HAtb7NqMX3KDdY5eHTWYVjlGqmTiUNG/XgiZ6iKXll4+LxxZkdNY7GAgOjxgISnWRf6HWIoy5go8A==",
+			"dependencies": {
+				"@react-types/link": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/button": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.6.0.tgz",
+			"integrity": "sha512-ijCi07TkLmwU3Qtn8IzKJi1nugZj8Ln0+w2OZPRJS/tRFv48qgNsOXum54W5i9W0yg/I7VQiPjm+YsQS51g7gA==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/calendar": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.0.1.tgz",
+			"integrity": "sha512-Pb0aS4k7t6rIJ5RbHulC3GILLDscVHaoXUN8kQ5Er/GsxXCbxX2Iw8SbSJFub5UnjhgGA1+B5URGCeRhRi8bNg==",
+			"dependencies": {
+				"@internationalized/date": "^3.0.1",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/checkbox": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.3.2.tgz",
+			"integrity": "sha512-s1bgqL4qfEMEasePayukZ6pzpIzfAG1OuVmpARz0kVdVaN7e+B4+dRJ0nDtiQf/TjNLg45ZlG3NTXJ1hsZPelQ==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/combobox": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.5.2.tgz",
+			"integrity": "sha512-Q1HtiT/Hq+b6q71Evn8nmIfLv08kDEZSlOz5hlZouH9ZGYeTb1huH72biYl9LyIB6NRdNUouo7+I8ddumeAkMA==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/datepicker": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.1.0.tgz",
+			"integrity": "sha512-hnTdwWP/eqZ1HYEEGuSRfi99dwDbeC6PmgQD686PVMmXc1YTvphI6lDLwR2tuTEywhe6X1djDVB2aMEckV6WLg==",
+			"dependencies": {
+				"@internationalized/date": "^3.0.1",
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/dialog": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.4.2.tgz",
+			"integrity": "sha512-ub5KrXuN0VELqIKDKuj+ySalcliIneuVnwnX83XbW+xSs9/zFo5WwALU0YxP77rzwIyuu6ziQ8CUZ7rHhLa0hQ==",
+			"dependencies": {
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/grid": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.1.2.tgz",
+			"integrity": "sha512-9mKhtBZiGlok1APRSR+hTKYFgx8XxRBBLG20/xPI1C8xCGNZvOz7CmK57LmlwYsN1BLo3S2vLOd6+M1qrw2yVg==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/label": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-types/label/-/label-3.6.2.tgz",
+			"integrity": "sha512-fxivJ3MKYbNhE8z/zPpmvN2R7XNGpaTQ5Rm7/ueIou5VkrZnZmDJv0+wIs9xF8l6Bq6Nx7k899OK0u38XTgwNw==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/link": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.3.2.tgz",
+			"integrity": "sha512-owkHLd639ZU1Tkw/aR53OXvVVMS1irfH2lcqptEVlIzQSLM24/3v6vuO5AaeAeqfF974xFnlOIKLdQ+HI6AURw==",
+			"dependencies": {
+				"@react-aria/interactions": "^3.10.0",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/listbox": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.3.2.tgz",
+			"integrity": "sha512-4HYydDJhI6oz1MsHccKZj2E24YjYlTNO92hUsZnqAVl21NQrNu4h2Ac8TqsI3ZhorpzcxHN0xeQTzjqO97NloA==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/menu": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.7.0.tgz",
+			"integrity": "sha512-1kEyyb0tERlPdZ67lsC2fMZ2TTh0OdS1hcb01PrSkGna/S+H/Q9M65Xc+q9eu7QoC4+DN4Flh/7vNRT82kVlHg==",
+			"dependencies": {
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/meter": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.2.2.tgz",
+			"integrity": "sha512-SZ5iH+ZgXOxjsDzpA49Pq0WWiBZC50LmyK7FxtZg9VhhsrySkpYQ9GZUWTjnAp42/k/LvMIpctp+dG6mXaiAjg==",
+			"dependencies": {
+				"@react-types/progress": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/numberfield": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.3.2.tgz",
+			"integrity": "sha512-+vWiOqDFidQHvAiOKnLjMgxtDobxyN02Sb+47dSoyuEo3bSxXvBbAMkukD35yseBqfqP2FRzxQ3R3s4mWI8SWw==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/overlays": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.6.2.tgz",
+			"integrity": "sha512-ag9UCIlcNCvMHBORRksdLnQK3ef+CEbrt+TydOxBAxAf+87fXJ/0H6hP/4QTebEA2ixA0qz8CFga81S8ZGnOsQ==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/progress": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.2.2.tgz",
+			"integrity": "sha512-bCt5kubeIrjU+NRODJjarBqynKaIEwfo14ndX/6z9eXsYiGpH9o08bdIk0gS249y7ExtOSUzdRn1s92DOYVmjQ==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/radio": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.2.2.tgz",
+			"integrity": "sha512-JBnfEUu4T6Z+SRsALKnzmx/4AqeIbdHEOumHSlAlX5iLPUywvELn22PVvF+YHh7bOeXKcVv+4/rXnTZWcsAK1g==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/searchfield": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.3.2.tgz",
+			"integrity": "sha512-j7heJdOBftJi73fd2XzpQxGhtuGQGWH5wPwHlyo8JXr9PCUFk5Hq7bYHLU/CD08Q950Z7rcPXM4ntuDzzmxPHg==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0",
+				"@react-types/textfield": "^3.5.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/select": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.6.2.tgz",
+			"integrity": "sha512-V1ahKVEIA+u4kDOXTw0UoSjJ8T3EJi25PNx/whLYIEMXWw/v8dH+x7Hi7S45cHS+ZxoZXhWIV8WmgDKIUp1U1Q==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/shared": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.14.0.tgz",
+			"integrity": "sha512-K069Bh/P0qV3zUG8kqabeO8beAUlFdyVPvpcNVPjRl+0Q9NDS9mfdQbmUa0LqdVo5e6jRPdos77Ylflkrz8wcw==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/slider": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.2.0.tgz",
+			"integrity": "sha512-olhfWQiZTroGBkS62oX2dQN+ebfXejDLPaH83JfnBTx7Mtu/qkBfINjGMG7AMR+/Dbgq13n8RcymMIQHzEjSVw==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/switch": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.2.2.tgz",
+			"integrity": "sha512-DGJP4+3B6yQ86/WaGL9aLjWyLb9x1lAHW1+cXEl016/J2BdlU83Lw4mRr1qaniGLd+1Ft6cvVv7419voPlf3Ng==",
+			"dependencies": {
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/table": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.3.0.tgz",
+			"integrity": "sha512-spq1h0+RuClbedH26d8SX8bGJUWO3x/MrRuoxN/XThCR+8rayp+QjCz7Pz2a5rqMniRh91O8rOOdqjbWbP4b7g==",
+			"dependencies": {
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/tabs": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.1.2.tgz",
+			"integrity": "sha512-IrVf2C71xGfIguO8Dtb3uyVHDLraIftOylp0+cKcXaRukrlcvr9xiucgGaOI3+7K2W6UX/QrVDUazBI5lOK1Yw==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/textfield": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.5.2.tgz",
+			"integrity": "sha512-GPZd8h0eji+eywV4sM98IvvNBM+uY2/GcL7KyEqf0r2gMOZy7W81JCGCuGaGGcZYxsv0yu/NmZbzQHijKW9cNg==",
+			"dependencies": {
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/tooltip": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.2.2.tgz",
+			"integrity": "sha512-EAvIOOaHvkxg8vIDXKJc8Sac7wLN80Erp6MH+kr7Ybmr94SHH7jnOPF6CkfcDE2WqYm5vqyerc6MPO/iQVyhZg==",
+			"dependencies": {
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
 			}
 		},
 		"node_modules/@sideway/address": {
@@ -3224,14 +4621,66 @@
 				"react-autosize-textarea": "^7.1.0"
 			}
 		},
+		"node_modules/@types/wordpress__block-editor/node_modules/react": {
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/react-autosize-textarea": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+			"dependencies": {
+				"autosize": "^4.0.2",
+				"line-height": "^0.3.1",
+				"prop-types": "^15.5.6"
+			},
+			"peerDependencies": {
+				"react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/react-dom": {
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.19.1"
+			},
+			"peerDependencies": {
+				"react": "^16.14.0"
+			}
+		},
+		"node_modules/@types/wordpress__block-editor/node_modules/scheduler": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
+		},
 		"node_modules/@types/wordpress__blocks": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.5.tgz",
-			"integrity": "sha512-DO5PMIM+zhuLtLzykYD1Z92aBo7hoEpXbi9Rg3LwDeVphBDIBdU7T9t0hwJPVRCtAUZdzHwpq3dNPbx2yw2r2g==",
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.7.tgz",
+			"integrity": "sha512-8BcT3CUxHt73CepaLtQHAhA7uBhDOK9x5HJOAxzV+Bl37W04u4jSNulXxwX/6tI7t7Knux5lnN9bvKf/1sg+Rw==",
 			"dependencies": {
 				"@types/react": "*",
 				"@types/wordpress__components": "*",
-				"@types/wordpress__data": "*",
 				"@wordpress/element": "^4.0.0"
 			}
 		},
@@ -5706,6 +7155,11 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
 			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
 		},
+		"node_modules/classnames": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+		},
 		"node_modules/clean-webpack-plugin": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
@@ -5812,6 +7266,14 @@
 			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/co": {
@@ -6899,9 +8361,9 @@
 			}
 		},
 		"node_modules/downshift": {
-			"version": "6.1.7",
-			"resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.7.tgz",
-			"integrity": "sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==",
+			"version": "6.1.9",
+			"resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.9.tgz",
+			"integrity": "sha512-mzvk61WOX4MEsYHMKCXEVwuz/zM84x/WrCbaCQw71hyNN0fmWXvV673uOQy2idgIA+yqDsjtkV5KPfAFWuQylg==",
 			"dependencies": {
 				"@babel/runtime": "^7.14.8",
 				"compute-scroll-into-view": "^1.0.17",
@@ -9460,6 +10922,22 @@
 			"engines": {
 				"node": ">= 0.10"
 			}
+		},
+		"node_modules/intl-messageformat": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.1.tgz",
+			"integrity": "sha512-FeJne2oooYW6shLPbrqyjRX6hTELVrQ90Dn88z7NomLk/xZBCLxLPAkgaYaTQJBRBV78nZ933d8APHHkTQrD9Q==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.11.8",
+				"@formatjs/fast-memoize": "1.2.4",
+				"@formatjs/icu-messageformat-parser": "2.1.4",
+				"tslib": "2.4.0"
+			}
+		},
+		"node_modules/intl-messageformat/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/ipaddr.js": {
 			"version": "2.0.1",
@@ -13511,18 +14989,46 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/react-autosize-textarea": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
-			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+		"node_modules/react-aria": {
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.18.0.tgz",
+			"integrity": "sha512-sJwR6Utoq3zBg/sWG8Cu372zhxBiXQ31AZiy4thV6aa9N54yKZzM//JREPBH/RySQXFwkhZgakEh91RBOrfNrQ==",
 			"dependencies": {
-				"autosize": "^4.0.2",
-				"line-height": "^0.3.1",
-				"prop-types": "^15.5.6"
+				"@react-aria/breadcrumbs": "^3.3.0",
+				"@react-aria/button": "^3.6.0",
+				"@react-aria/calendar": "^3.0.1",
+				"@react-aria/checkbox": "^3.5.0",
+				"@react-aria/combobox": "^3.4.0",
+				"@react-aria/datepicker": "^3.1.0",
+				"@react-aria/dialog": "^3.3.0",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/link": "^3.3.2",
+				"@react-aria/listbox": "^3.6.0",
+				"@react-aria/menu": "^3.6.0",
+				"@react-aria/meter": "^3.3.0",
+				"@react-aria/numberfield": "^3.3.0",
+				"@react-aria/overlays": "^3.10.0",
+				"@react-aria/progress": "^3.3.0",
+				"@react-aria/radio": "^3.3.0",
+				"@react-aria/searchfield": "^3.4.0",
+				"@react-aria/select": "^3.8.0",
+				"@react-aria/separator": "^3.2.2",
+				"@react-aria/slider": "^3.2.0",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-aria/switch": "^3.2.2",
+				"@react-aria/table": "^3.4.0",
+				"@react-aria/tabs": "^3.3.0",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/tooltip": "^3.3.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-aria/visually-hidden": "^3.4.0"
 			},
 			"peerDependencies": {
-				"react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-				"react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
 			}
 		},
 		"node_modules/react-dom": {
@@ -13561,6 +15067,37 @@
 			},
 			"peerDependencies": {
 				"react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/react-stately": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.16.0.tgz",
+			"integrity": "sha512-V+/sIjSt8xui0axxJ0DbiV3KiozCiynF1zCjroJBCaO9qUw/LL4yJoRK80YwQa6Ami9u7y+Ti7Q4Gu7XsMmZ6w==",
+			"dependencies": {
+				"@react-stately/calendar": "^3.0.1",
+				"@react-stately/checkbox": "^3.2.0",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/combobox": "^3.2.0",
+				"@react-stately/data": "^3.6.0",
+				"@react-stately/datepicker": "^3.0.1",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/numberfield": "^3.2.0",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/radio": "^3.5.0",
+				"@react-stately/searchfield": "^3.3.0",
+				"@react-stately/select": "^3.3.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/slider": "^3.2.0",
+				"@react-stately/table": "^3.3.0",
+				"@react-stately/tabs": "^3.2.0",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-stately/tooltip": "^3.2.0",
+				"@react-stately/tree": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
 			}
 		},
 		"node_modules/react-test-renderer": {
@@ -17883,6 +19420,85 @@
 				}
 			}
 		},
+		"@formatjs/ecma402-abstract": {
+			"version": "1.11.8",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
+			"integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
+			"requires": {
+				"@formatjs/intl-localematcher": "0.2.28",
+				"tslib": "2.4.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
+		"@formatjs/fast-memoize": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.4.tgz",
+			"integrity": "sha512-9ARYoLR8AEzXvj2nYrOVHY/h1dDMDWGTnKDLXSISF1uoPakSmfcZuSqjiqZX2wRkEUimPxdwTu/agyozBtZRHA==",
+			"requires": {
+				"tslib": "2.4.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
+		"@formatjs/icu-messageformat-parser": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.4.tgz",
+			"integrity": "sha512-3PqMvKWV1oyok0BuiXUAHIaotdhdTJw6OICqCZbfUgKT+ZRwRWO4IlCgvXJeCITaKS5p+PY0XXKjf/vUyIpWjQ==",
+			"requires": {
+				"@formatjs/ecma402-abstract": "1.11.8",
+				"@formatjs/icu-skeleton-parser": "1.3.10",
+				"tslib": "2.4.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
+		"@formatjs/icu-skeleton-parser": {
+			"version": "1.3.10",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.10.tgz",
+			"integrity": "sha512-kXJmtLDqFF5aLTf8IxdJXnhrIX1Qb4Qp3a9jqRecGDYfzOa9hMhi9U0nKyhrJJ4cXxBzptcgb+LWkyeHL6nlBQ==",
+			"requires": {
+				"@formatjs/ecma402-abstract": "1.11.8",
+				"tslib": "2.4.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
+		"@formatjs/intl-localematcher": {
+			"version": "0.2.28",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.28.tgz",
+			"integrity": "sha512-FLsc6Gifs1np/8HnCn/7Q+lHMmenrD5fuDhRT82yj0gi9O19kfaFwjQUw1gZsyILuRyT93GuzdifHj7TKRhBcw==",
+			"requires": {
+				"tslib": "2.4.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
 		"@fullhuman/postcss-purgecss": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.1.3.tgz",
@@ -17923,6 +19539,39 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+		},
+		"@internationalized/date": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.0.1.tgz",
+			"integrity": "sha512-E/3lASs4mAeJ2Z2ye6ab7eUD0bPUfTeNVTAv6IS+ne9UtMu9Uepb9A1U2Ae0hDr6WAlBuvUtrakaxEdYB9TV6Q==",
+			"requires": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"@internationalized/message": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.0.9.tgz",
+			"integrity": "sha512-yHQggKWUuSvj1GznVtie4tcYq+xMrkd/lTKCFHp6gG18KbIliDw+UI7sL9+yJPGuWiR083xuLyyhzqiPbNOEww==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"intl-messageformat": "^10.1.0"
+			}
+		},
+		"@internationalized/number": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.1.1.tgz",
+			"integrity": "sha512-dBxCQKIxvsZvW2IBt3KsqrCfaw2nV6o6a8xsloJn/hjW0ayeyhKuiiMtTwW3/WGNPP7ZRyDbtuiUEjMwif1ENQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"@internationalized/string": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.0.0.tgz",
+			"integrity": "sha512-NUSr4u+mNu5BysXFeVWZW4kvjXylPkU/YYqaWzdNuz1eABfehFiZTEYhWAAMzI3U8DTxfqF9PM3zyhk5gcfz6w==",
+			"requires": {
+				"@babel/runtime": "^7.6.2"
+			}
 		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -18316,6 +19965,1035 @@
 				"linguist-languages": "^7.21.0",
 				"mem": "^8.0.0",
 				"php-parser": "3.1.0-beta.11"
+			}
+		},
+		"@react-aria/breadcrumbs": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.3.0.tgz",
+			"integrity": "sha512-pQonjZeBeVgyUWEZ/Ip0d7Claal2AtUPv1zkk5PI+X0g0C58B6ouRM3ZjGwoQ1Qzs4u9nrXGkcwMWga/Zxqy0Q==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/link": "^3.3.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/breadcrumbs": "^3.4.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/button": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.6.0.tgz",
+			"integrity": "sha512-+I+raFN5Kw85WzgmiIEQG0JhJ+WSCWJRSCgA0Nc4Wvjkm7gQSRvhSzSZiI7HQxz43h0MgFbuX/ruRn1WKPLsLg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/calendar": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.0.1.tgz",
+			"integrity": "sha512-7EejTAq1KRO0sNKegxCMW/98hSGofBvjktgQBmZea7F6JG+otadASqqS4mdz86s86LN9mDSTUJWljdJ3L/UYTw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/calendar": "^3.0.1",
+				"@react-types/button": "^3.6.0",
+				"@react-types/calendar": "^3.0.1",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/checkbox": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.5.0.tgz",
+			"integrity": "sha512-U3SXfiVus/aF3S3v9aTPILRZBnUzHs5JJhile9CXIe1YoPam8u12s4G+aS55rrwoa3XLcnvZbPbwlShcc8bjaA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/toggle": "^3.3.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/checkbox": "^3.2.0",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/combobox": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.4.0.tgz",
+			"integrity": "sha512-XJrPXGUroSh536/+Ud4akQ9+r9wJKzJxZDIE1S2gWxf0zGqbWPtSrKk6Eg7oVEJHcWi7rETmmFZM7othiDRWaA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/listbox": "^3.6.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/menu": "^3.6.0",
+				"@react-aria/overlays": "^3.10.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/combobox": "^3.2.0",
+				"@react-stately/layout": "^3.6.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/combobox": "^3.5.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/datepicker": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.1.0.tgz",
+			"integrity": "sha512-nkidFlr+0V3c7K4KwBW4G2AkIHzKGjzZBrjduXOrVxZSXbC69vvr11SrsHUWczMjC1ozEkX1WAHBiizxLdotXQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@internationalized/number": "^3.1.1",
+				"@internationalized/string": "^3.0.0",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/spinbutton": "^3.1.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/datepicker": "^3.0.1",
+				"@react-types/button": "^3.6.0",
+				"@react-types/calendar": "^3.0.1",
+				"@react-types/datepicker": "^3.1.0",
+				"@react-types/dialog": "^3.4.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/dialog": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.3.0.tgz",
+			"integrity": "sha512-kzJLjIYIRpK+ASOpOSY56sE6l+rpmk4QvIqTjrqlynXdneGVgNVu3OxX37U73Zn53is7ivbT+TugCzHTgle0qg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-types/dialog": "^3.4.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/focus": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.7.0.tgz",
+			"integrity": "sha512-LydZSLBLEUklakM0Ogdk17F3f/Uwaj5Nl1mfcK8HhrroGT8A8XH0KjA9D6gM6JGHgxZemx0ufOgxhQZeBGQMQw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0",
+				"clsx": "^1.1.1"
+			}
+		},
+		"@react-aria/grid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.4.0.tgz",
+			"integrity": "sha512-izIig52FV+uRzRuenRZ8CNLoivpT5yXsN6414RXKNnyCWDfBrllUvJYndll0ngrBKTjd6tmqJM8Y3kja/7+A9A==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/grid": "^3.3.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/virtualizer": "^3.2.2",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/i18n": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.5.1.tgz",
+			"integrity": "sha512-PtlQ/W1PXVKzCGK86MuGuCzYBwENDBjrQ2a4ux+BBQ2Dk8ZXEARSp9JaMFuOdiloXc/p4FoxCVoB+lhu4RCScg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@internationalized/message": "^3.0.9",
+				"@internationalized/number": "^3.1.1",
+				"@internationalized/string": "^3.0.0",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/interactions": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.10.0.tgz",
+			"integrity": "sha512-Lp74VfF+EskT3IqK2MBMdJpJU48p60+YkMbgtoDF6LudNO8jw0nxcsvnimPriTSkZWINRpajG/9sIa0EIDcQKw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/label": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.4.0.tgz",
+			"integrity": "sha512-QqyZMuSdnH+7mkAbZbGtLU3NhSz2luNCeM+ZJPQ3ANegrdXsKwERSwD2/ERHAC5FGLqwlzXnPhRcYdvjafg/Ug==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/label": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/link": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.3.2.tgz",
+			"integrity": "sha512-auGW+HK7kq7iMntkMl5JzWnWufxwqpFcU4HnSA5W9HEZN8Gj+WWdY9QmAYXn0GulcuCCoDAsK64AUtsFrlrXzg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/link": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/listbox": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.6.0.tgz",
+			"integrity": "sha512-AQ7Vdn5EKBBipFkEaV5uvamPdkXhDoILdGfFj/82X5miJBOzmu+gYVZ97njVVsGn+RYi8saK2VFcKeMXHOoYVQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-types/listbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/live-announcer": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.1.1.tgz",
+			"integrity": "sha512-e7b+dRh1SUTla42vzjdbhGYkeLD7E6wIYjYaHW9zZ37rBkSqLHUhTigh3eT3k5NxFlDD/uRxTYuwaFnWQgR+4g==",
+			"requires": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"@react-aria/menu": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.6.0.tgz",
+			"integrity": "sha512-s083I10XG/K06V7wOF+VYGgUwg6ZwlmsmLlrXyFRzCVK6LXimNNC/mOeSZet6m4R4H1svtH+US/v+/eD6pkdUQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/overlays": "^3.10.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/tree": "^3.3.2",
+				"@react-types/button": "^3.6.0",
+				"@react-types/menu": "^3.7.0",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/meter": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.3.0.tgz",
+			"integrity": "sha512-svLFhWgpi6WBtStLFI7bXk9wMrLAl/8YYoEC5oUpk3B0DXgyBXx3o8/SHqSab9nNJEepfQXLvC0PVoL6116h3A==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/progress": "^3.3.0",
+				"@react-types/meter": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/numberfield": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.3.0.tgz",
+			"integrity": "sha512-BzFiwPwS1VvAsHK3OH0Dczec+ZJ8C09pfr+KRJQMVC5+CjXoX9jImu4WA6SyyD8BKQe7dg6McQsLLryBODgvNg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/spinbutton": "^3.1.2",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/numberfield": "^3.2.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/numberfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/textfield": "^3.5.2"
+			}
+		},
+		"@react-aria/overlays": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.10.0.tgz",
+			"integrity": "sha512-A7aI59/o4tUAISjyyRfJz3833SLe4ZKPNoxOVUzgjfkfnCKq7YDSSEC5poxDqYD9bq/NBXK6stdgaGLXQSirNw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-aria/visually-hidden": "^3.4.0",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/progress": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.3.0.tgz",
+			"integrity": "sha512-VenJJWOErvD12RKoffQomlTc2Zl6snrTT6aoM6APApW/QORUyyI8VW6CTUM68RkoQ0q3qySjsL+7yyrd6sping==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/progress": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/radio": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.3.0.tgz",
+			"integrity": "sha512-UhPxFVYKaPI8a9bF6XOl5Q7lbgW7YlrLTHnjOhxiUWvyyOsOnseiSgF9TqSfhhsF7HNYdOt1u3Xwx3vrHniCBg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/radio": "^3.5.0",
+				"@react-types/radio": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/searchfield": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.4.0.tgz",
+			"integrity": "sha512-12NodopxqWdQYQvxuKJN9RE/qBTcVVF1OgF5589jm9iVicqaedG1QJG2aUcaNsVZUgl9xKgCSfaNNwv8tcHS1g==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/searchfield": "^3.3.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/searchfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/select": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.8.0.tgz",
+			"integrity": "sha512-9lWQ22iWvcx1DCaguwkwQXnV8izD8t0LOD3PPHaA2I2QKyKgk4c3iBYlf2zaEI3zCySZc0EhWOQOIljOgejOiA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/listbox": "^3.6.0",
+				"@react-aria/menu": "^3.6.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-aria/visually-hidden": "^3.4.0",
+				"@react-stately/select": "^3.3.0",
+				"@react-types/button": "^3.6.0",
+				"@react-types/select": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/selection": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.10.0.tgz",
+			"integrity": "sha512-VvFgNRrM0kK6aqyMTeTN+pguyvYN9Wu3viftnZyk89uo2+9hfmU7DLhz5kXkdJY9UNzn033jYGwJdWEuqRq65g==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/separator": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.2.2.tgz",
+			"integrity": "sha512-Kpd1aZllhC0V95vTRLxiMp7daAfUg8tz1cfur6HcPv1c1QMi1IgwEkUuLIhJAwfmloJ/nzorlNOVJuseiv4L4Q==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/slider": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.2.0.tgz",
+			"integrity": "sha512-hHlPWGjiZsn07ptuPWw/PQ8vApjis9eu7G5K/H+q8iQJHJU+BADi4WScXBy7xqJKrJ7do3htIGBzJkWycf/YYw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/radio": "^3.5.0",
+				"@react-stately/slider": "^3.2.0",
+				"@react-types/radio": "^3.2.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/slider": "^3.2.0"
+			}
+		},
+		"@react-aria/spinbutton": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.1.2.tgz",
+			"integrity": "sha512-z41S6S9JSTVqboQiJZGIWeElk3WPpibGeCStTehJjYuYNy9Ap6yk6cYNe6UdZ+rikYI1oTw3Ycm2PMkwZERDzw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/button": "^3.6.0",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-aria/ssr": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.3.0.tgz",
+			"integrity": "sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"@react-aria/switch": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.2.2.tgz",
+			"integrity": "sha512-xE8maB2gtQEADLWh/IfW/KaQqtEOSNSHrnH/zcFa8MwCmSElMdCypqhOx6DfA3vQzGeG/qTiXklACvt5m2p30Q==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/toggle": "^3.3.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/switch": "^3.2.2"
+			}
+		},
+		"@react-aria/table": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.4.0.tgz",
+			"integrity": "sha512-a3yYKRtadGzMrOJlGy2AGf2w2baESYgM2hZnB4YupBrcKJ/91BMpAbpAMolCI02av+Tz0BtAKh0kSs7nEsiiuA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/grid": "^3.4.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/live-announcer": "^3.1.1",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/table": "^3.3.0",
+				"@react-stately/virtualizer": "^3.2.2",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/table": "^3.3.0"
+			}
+		},
+		"@react-aria/tabs": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.3.0.tgz",
+			"integrity": "sha512-X6kVqKv/r25gIDvmN+UQTzLz2ScdDeqPI6yzutTJG39YkUFzD2u0GY45tvD8vi5fe8uHVQQEUjUpF9oejHOD7Q==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/selection": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/tabs": "^3.2.0",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/tabs": "^3.1.2"
+			}
+		},
+		"@react-aria/textfield": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.7.0.tgz",
+			"integrity": "sha512-Tarag7zRY4V1MKKnh7c8XlvUpYs99IBgEuwWmWcZw0wOQdiqh8qm7fiSJEAhYv9r66nZx/1BPpQM3zg2JnW4EQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/textfield": "^3.5.2"
+			}
+		},
+		"@react-aria/toggle": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.3.2.tgz",
+			"integrity": "sha512-U+npP5XtNBs+e5T1UZDw5UhG8PJwnx+p68+GTY20UMVCTHtuNyjzjmI9nI3b9oVGcJ3ZKfvQAWq2uOqBjF/W3A==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/switch": "^3.2.2"
+			}
+		},
+		"@react-aria/tooltip": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.3.0.tgz",
+			"integrity": "sha512-Ya5HoaSqOfF9m+OA+Y8damGn1jWrDk2hBjnjPe3J+daMn1tZndM2z8e59XzOSWPF+RWG8+aiWVCwL84Rl1r6sQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/tooltip": "^3.2.0",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/tooltip": "^3.2.2"
+			}
+		},
+		"@react-aria/utils": {
+			"version": "3.13.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.13.2.tgz",
+			"integrity": "sha512-VTI8tv9m/BxE/lPTNCZN1fcHuY540xm+HT1vg2ZQCryudUWvzQkHi+h0z32DhiGHhvRFIGdH/enf3psip7ZLTQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0",
+				"clsx": "^1.1.1"
+			}
+		},
+		"@react-aria/visually-hidden": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.4.0.tgz",
+			"integrity": "sha512-mRl4Vfg7F0ohf7N3RWdOQLUnXC4ApM3hsfBegsRQHDkbbrcq7MGPyCa154kIZg8Ff2cOtbgvrAlymzWmkOVZEQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0",
+				"clsx": "^1.1.1"
+			}
+		},
+		"@react-stately/calendar": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.0.1.tgz",
+			"integrity": "sha512-UBc6ZVRFxykPDt2EH7iLzax6aIrIVLtrhMs8M92iqjoLgVKs1uFPQIGYq/KzZ5nbwI7Ga43B7ZX8/TpZHTAAFw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/calendar": "^3.0.1",
+				"@react-types/datepicker": "^3.1.0",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/checkbox": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.2.0.tgz",
+			"integrity": "sha512-nVO/asz7MTF5nLJcMMq5KgNlk4npckq+7nQvEVW6pyob5r2m7Lvd+Zhl4oKT0WtTIzg31VB6yRew1czKx/SUpA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/checkbox": "^3.3.2"
+			}
+		},
+		"@react-stately/collections": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.4.2.tgz",
+			"integrity": "sha512-CmLVWtbX4r3QaTNdI6edtrRKIZRKPuxyD7TmVIaoZBdaOXStTP4wOgyPN1ELww9bvW0MoOaQBbUn5WAPrfifFw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/combobox": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.2.0.tgz",
+			"integrity": "sha512-77TOvsqBk5xBKc19PIAsi/w7T0lKXMxsOvSfWlOG/StF14d5TJUuhk7CJWCzSgAl3LVhuAKKq5AeZMKAfIrB3w==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/select": "^3.3.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/combobox": "^3.5.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/data": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.6.0.tgz",
+			"integrity": "sha512-psuc5nziuPWYdxIFhXEt9DBT+cuhOCyGPz8cOP5RuWFfSM4r583M0SYrsi5YXCvUwhZEFFQNbapxJFfMpAHPtw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/datepicker": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.0.1.tgz",
+			"integrity": "sha512-mUvDxL6BpC9/BIs7E4f7OeVK/OwZ+gG6X549DBopJLUyVfFrQWZw5NcuEeie28WLwzYdfmhqv5NbkdWqmhjNpA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/date": "^3.0.1",
+				"@internationalized/string": "^3.0.0",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/datepicker": "^3.1.0",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/grid": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.3.0.tgz",
+			"integrity": "sha512-30z4Kki5QWZvR22f3UrA18eMDOcXmQFzAq5pHbRs1LvxJAaqeAD2KzCT70MCgoA5XzyiOrvIPrKTBRf48du45w==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/layout": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-3.6.0.tgz",
+			"integrity": "sha512-X77WiMImtosPDRdJKPYR0oYTKWe/g34ZrpYWxKSVZjc9N6tqcj24p1lMIq/ZRZ1qOlLv9Y41vLYtm8uk5fdaMA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/virtualizer": "^3.2.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/table": "^3.3.0"
+			}
+		},
+		"@react-stately/list": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.5.2.tgz",
+			"integrity": "sha512-Jv8xzO5oanEMAblLiUUr7uwkMTd5qyczyjxJrv8O52Lwd4GwzJ1w7KggTSZ7JG99fLZozLor3p0foVVvSI1/NA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/menu": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.4.0.tgz",
+			"integrity": "sha512-xdNS3K0PmSjpNhH/Xnskfexxyo909Jkkfux4zhP5Ivk4Vkp0eThb6v9AIomUAo163PuOnHQFen1ZmwFEs92xMw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/menu": "^3.7.0",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/numberfield": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.2.0.tgz",
+			"integrity": "sha512-NMnrRntWJ8SnU37Zc5+QVq7x+5uJAT8X7qxmU3Uka+r8RNUycWg8Z5tvrBxL41phlBb+EnK62Bha7RypZrcrYQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@internationalized/number": "^3.1.1",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/numberfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/overlays": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.4.0.tgz",
+			"integrity": "sha512-jXVm1V91lWOKh73cFvE9W9JtAE8idSWEUtFlVrlBI/jh0ZOt148UlRVWgHrm7FhaUpyvOFNUyfidRmKMuB+hgw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/overlays": "^3.6.2"
+			}
+		},
+		"@react-stately/radio": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.5.0.tgz",
+			"integrity": "sha512-qn4+wa9sf3zZXSLrrR9rQpOII8BEQeAkvxyq/YhUQXBpQ8SoF5LobpGIZqp3n8G+Cxzjxd6/GON+lOFxWr0iXA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/radio": "^3.2.2"
+			}
+		},
+		"@react-stately/searchfield": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.3.0.tgz",
+			"integrity": "sha512-M7j0RiDBIZ7q48ZdTgPD7kCo+H9QkpBfCndcCzHAhTaCLkZchEEbJ9cQjvaRYRZCgTh40qzQPlL8KeEJm1NvGw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/searchfield": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/select": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.3.0.tgz",
+			"integrity": "sha512-amF7N8izlD8Dtja75uPdvBMme9KTwuJ6HHtPAVtoVOdSDcD7yb8GTRNhsjvfW8YPm8jkrUwkSobegqaEtRM5eQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/select": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/selection": {
+			"version": "3.10.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.10.2.tgz",
+			"integrity": "sha512-3/iw0BpShWt5ie+YpOzi4Mpa3yKOtlKQZXEc0fZt3v3m3N3fMoCr7Ovkfuz5Svy47HIIN1Pk1WkRJC+CQ4hfDw==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/slider": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.2.0.tgz",
+			"integrity": "sha512-3WdG6+qEZZz/EkO6HZZXtMT25kzdaoxeUSVD+fByb7hE3aS6eb+OAJEy6LDpN7DVTBpkGhHMdRdnTT7+mntzPQ==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/slider": "^3.2.0"
+			}
+		},
+		"@react-stately/table": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.3.0.tgz",
+			"integrity": "sha512-qhZdgyD0EyePW/U/VlJCGLBNuzo2H1hQSgfRJ7+E5QVbqDwUUQ6Safz1EQ3Jhh64IcTDqxvKL3arr8THT7UKdA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/grid": "^3.3.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0",
+				"@react-types/table": "^3.3.0"
+			}
+		},
+		"@react-stately/tabs": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.2.0.tgz",
+			"integrity": "sha512-HeICk4D0mxnqmSoxJ6FI2CRHaTANIxDrJ2UTzoK9y+mMIC+ZUzXxtANda6TQ5wTOY7xUqITCHDSzxTiaI/090g==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/tabs": "^3.1.2"
+			}
+		},
+		"@react-stately/toggle": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.4.0.tgz",
+			"integrity": "sha512-7kPxR2+Aze7NmpWWOQanRsQvmz7R+Sdlu+2xi0Wh5LPFg+lkXSiGY63uM2amxZcbFb0Mhy5ExlRpF53ReZjEOA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/tooltip": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.2.0.tgz",
+			"integrity": "sha512-OoO/vUPWLJG05sV2fPH5K7kt+aMBqFgxKn59LxvGzS4hCeI58WLeGeJhbEOwMyF9+GO7JtdUssVrqMeahKUrzg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/tooltip": "^3.2.2"
+			}
+		},
+		"@react-stately/tree": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.3.2.tgz",
+			"integrity": "sha512-goviIXFYZvWJ2FOBQdKHfLwCaFUlhyGCsbX9GB7ziZhm0Ez8iWCzEy1IWoeuPaprBlHIPv6/3XtDi4ZQ52A59g==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/utils": "^3.5.1",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-stately/utils": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.5.1.tgz",
+			"integrity": "sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==",
+			"requires": {
+				"@babel/runtime": "^7.6.2"
+			}
+		},
+		"@react-stately/virtualizer": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-3.2.2.tgz",
+			"integrity": "sha512-I0dbohDkG+Gm750YxlAp9qy6uE3HxWRBQjrvBdswuIscaBVp/espYqMvgVwxVnQnkcIcVdKZZ/gvT8HZwkR9lg==",
+			"requires": {
+				"@babel/runtime": "^7.6.2",
+				"@react-aria/utils": "^3.13.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/breadcrumbs": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.4.2.tgz",
+			"integrity": "sha512-CfLsyHXL2HAtb7NqMX3KDdY5eHTWYVjlGqmTiUNG/XgiZ6iKXll4+LxxZkdNY7GAgOjxgISnWRf6HWIoy5go8A==",
+			"requires": {
+				"@react-types/link": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/button": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.6.0.tgz",
+			"integrity": "sha512-ijCi07TkLmwU3Qtn8IzKJi1nugZj8Ln0+w2OZPRJS/tRFv48qgNsOXum54W5i9W0yg/I7VQiPjm+YsQS51g7gA==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/calendar": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.0.1.tgz",
+			"integrity": "sha512-Pb0aS4k7t6rIJ5RbHulC3GILLDscVHaoXUN8kQ5Er/GsxXCbxX2Iw8SbSJFub5UnjhgGA1+B5URGCeRhRi8bNg==",
+			"requires": {
+				"@internationalized/date": "^3.0.1",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/checkbox": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.3.2.tgz",
+			"integrity": "sha512-s1bgqL4qfEMEasePayukZ6pzpIzfAG1OuVmpARz0kVdVaN7e+B4+dRJ0nDtiQf/TjNLg45ZlG3NTXJ1hsZPelQ==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/combobox": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.5.2.tgz",
+			"integrity": "sha512-Q1HtiT/Hq+b6q71Evn8nmIfLv08kDEZSlOz5hlZouH9ZGYeTb1huH72biYl9LyIB6NRdNUouo7+I8ddumeAkMA==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/datepicker": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.1.0.tgz",
+			"integrity": "sha512-hnTdwWP/eqZ1HYEEGuSRfi99dwDbeC6PmgQD686PVMmXc1YTvphI6lDLwR2tuTEywhe6X1djDVB2aMEckV6WLg==",
+			"requires": {
+				"@internationalized/date": "^3.0.1",
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/dialog": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.4.2.tgz",
+			"integrity": "sha512-ub5KrXuN0VELqIKDKuj+ySalcliIneuVnwnX83XbW+xSs9/zFo5WwALU0YxP77rzwIyuu6ziQ8CUZ7rHhLa0hQ==",
+			"requires": {
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/grid": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.1.2.tgz",
+			"integrity": "sha512-9mKhtBZiGlok1APRSR+hTKYFgx8XxRBBLG20/xPI1C8xCGNZvOz7CmK57LmlwYsN1BLo3S2vLOd6+M1qrw2yVg==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/label": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-types/label/-/label-3.6.2.tgz",
+			"integrity": "sha512-fxivJ3MKYbNhE8z/zPpmvN2R7XNGpaTQ5Rm7/ueIou5VkrZnZmDJv0+wIs9xF8l6Bq6Nx7k899OK0u38XTgwNw==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/link": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.3.2.tgz",
+			"integrity": "sha512-owkHLd639ZU1Tkw/aR53OXvVVMS1irfH2lcqptEVlIzQSLM24/3v6vuO5AaeAeqfF974xFnlOIKLdQ+HI6AURw==",
+			"requires": {
+				"@react-aria/interactions": "^3.10.0",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/listbox": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.3.2.tgz",
+			"integrity": "sha512-4HYydDJhI6oz1MsHccKZj2E24YjYlTNO92hUsZnqAVl21NQrNu4h2Ac8TqsI3ZhorpzcxHN0xeQTzjqO97NloA==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/menu": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.7.0.tgz",
+			"integrity": "sha512-1kEyyb0tERlPdZ67lsC2fMZ2TTh0OdS1hcb01PrSkGna/S+H/Q9M65Xc+q9eu7QoC4+DN4Flh/7vNRT82kVlHg==",
+			"requires": {
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/meter": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.2.2.tgz",
+			"integrity": "sha512-SZ5iH+ZgXOxjsDzpA49Pq0WWiBZC50LmyK7FxtZg9VhhsrySkpYQ9GZUWTjnAp42/k/LvMIpctp+dG6mXaiAjg==",
+			"requires": {
+				"@react-types/progress": "^3.2.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/numberfield": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.3.2.tgz",
+			"integrity": "sha512-+vWiOqDFidQHvAiOKnLjMgxtDobxyN02Sb+47dSoyuEo3bSxXvBbAMkukD35yseBqfqP2FRzxQ3R3s4mWI8SWw==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/overlays": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.6.2.tgz",
+			"integrity": "sha512-ag9UCIlcNCvMHBORRksdLnQK3ef+CEbrt+TydOxBAxAf+87fXJ/0H6hP/4QTebEA2ixA0qz8CFga81S8ZGnOsQ==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/progress": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.2.2.tgz",
+			"integrity": "sha512-bCt5kubeIrjU+NRODJjarBqynKaIEwfo14ndX/6z9eXsYiGpH9o08bdIk0gS249y7ExtOSUzdRn1s92DOYVmjQ==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/radio": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.2.2.tgz",
+			"integrity": "sha512-JBnfEUu4T6Z+SRsALKnzmx/4AqeIbdHEOumHSlAlX5iLPUywvELn22PVvF+YHh7bOeXKcVv+4/rXnTZWcsAK1g==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/searchfield": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.3.2.tgz",
+			"integrity": "sha512-j7heJdOBftJi73fd2XzpQxGhtuGQGWH5wPwHlyo8JXr9PCUFk5Hq7bYHLU/CD08Q950Z7rcPXM4ntuDzzmxPHg==",
+			"requires": {
+				"@react-types/shared": "^3.14.0",
+				"@react-types/textfield": "^3.5.2"
+			}
+		},
+		"@react-types/select": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.6.2.tgz",
+			"integrity": "sha512-V1ahKVEIA+u4kDOXTw0UoSjJ8T3EJi25PNx/whLYIEMXWw/v8dH+x7Hi7S45cHS+ZxoZXhWIV8WmgDKIUp1U1Q==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/shared": {
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.14.0.tgz",
+			"integrity": "sha512-K069Bh/P0qV3zUG8kqabeO8beAUlFdyVPvpcNVPjRl+0Q9NDS9mfdQbmUa0LqdVo5e6jRPdos77Ylflkrz8wcw==",
+			"requires": {}
+		},
+		"@react-types/slider": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.2.0.tgz",
+			"integrity": "sha512-olhfWQiZTroGBkS62oX2dQN+ebfXejDLPaH83JfnBTx7Mtu/qkBfINjGMG7AMR+/Dbgq13n8RcymMIQHzEjSVw==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/switch": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.2.2.tgz",
+			"integrity": "sha512-DGJP4+3B6yQ86/WaGL9aLjWyLb9x1lAHW1+cXEl016/J2BdlU83Lw4mRr1qaniGLd+1Ft6cvVv7419voPlf3Ng==",
+			"requires": {
+				"@react-types/checkbox": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/table": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.3.0.tgz",
+			"integrity": "sha512-spq1h0+RuClbedH26d8SX8bGJUWO3x/MrRuoxN/XThCR+8rayp+QjCz7Pz2a5rqMniRh91O8rOOdqjbWbP4b7g==",
+			"requires": {
+				"@react-types/grid": "^3.1.2",
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/tabs": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.1.2.tgz",
+			"integrity": "sha512-IrVf2C71xGfIguO8Dtb3uyVHDLraIftOylp0+cKcXaRukrlcvr9xiucgGaOI3+7K2W6UX/QrVDUazBI5lOK1Yw==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/textfield": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.5.2.tgz",
+			"integrity": "sha512-GPZd8h0eji+eywV4sM98IvvNBM+uY2/GcL7KyEqf0r2gMOZy7W81JCGCuGaGGcZYxsv0yu/NmZbzQHijKW9cNg==",
+			"requires": {
+				"@react-types/shared": "^3.14.0"
+			}
+		},
+		"@react-types/tooltip": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.2.2.tgz",
+			"integrity": "sha512-EAvIOOaHvkxg8vIDXKJc8Sac7wLN80Erp6MH+kr7Ybmr94SHH7jnOPF6CkfcDE2WqYm5vqyerc6MPO/iQVyhZg==",
+			"requires": {
+				"@react-types/overlays": "^3.6.2",
+				"@react-types/shared": "^3.14.0"
 			}
 		},
 		"@sideway/address": {
@@ -18916,16 +21594,60 @@
 				"@types/wordpress__keycodes": "*",
 				"@wordpress/element": "^4.0.0",
 				"react-autosize-textarea": "^7.1.0"
+			},
+			"dependencies": {
+				"react": {
+					"version": "16.14.0",
+					"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+					"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+					"peer": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.2"
+					}
+				},
+				"react-autosize-textarea": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+					"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+					"requires": {
+						"autosize": "^4.0.2",
+						"line-height": "^0.3.1",
+						"prop-types": "^15.5.6"
+					}
+				},
+				"react-dom": {
+					"version": "16.14.0",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+					"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+					"peer": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.2",
+						"scheduler": "^0.19.1"
+					}
+				},
+				"scheduler": {
+					"version": "0.19.1",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+					"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+					"peer": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				}
 			}
 		},
 		"@types/wordpress__blocks": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.5.tgz",
-			"integrity": "sha512-DO5PMIM+zhuLtLzykYD1Z92aBo7hoEpXbi9Rg3LwDeVphBDIBdU7T9t0hwJPVRCtAUZdzHwpq3dNPbx2yw2r2g==",
+			"version": "11.0.7",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.7.tgz",
+			"integrity": "sha512-8BcT3CUxHt73CepaLtQHAhA7uBhDOK9x5HJOAxzV+Bl37W04u4jSNulXxwX/6tI7t7Knux5lnN9bvKf/1sg+Rw==",
 			"requires": {
 				"@types/react": "*",
 				"@types/wordpress__components": "*",
-				"@types/wordpress__data": "*",
 				"@wordpress/element": "^4.0.0"
 			}
 		},
@@ -20660,6 +23382,11 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
 			"integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
 		},
+		"classnames": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+		},
 		"clean-webpack-plugin": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
@@ -20736,6 +23463,11 @@
 					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 				}
 			}
+		},
+		"clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
 		},
 		"co": {
 			"version": "4.6.0",
@@ -21544,9 +24276,9 @@
 			}
 		},
 		"downshift": {
-			"version": "6.1.7",
-			"resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.7.tgz",
-			"integrity": "sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==",
+			"version": "6.1.9",
+			"resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.9.tgz",
+			"integrity": "sha512-mzvk61WOX4MEsYHMKCXEVwuz/zM84x/WrCbaCQw71hyNN0fmWXvV673uOQy2idgIA+yqDsjtkV5KPfAFWuQylg==",
 			"requires": {
 				"@babel/runtime": "^7.14.8",
 				"compute-scroll-into-view": "^1.0.17",
@@ -23421,6 +26153,24 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
 			"integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+		},
+		"intl-messageformat": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.1.tgz",
+			"integrity": "sha512-FeJne2oooYW6shLPbrqyjRX6hTELVrQ90Dn88z7NomLk/xZBCLxLPAkgaYaTQJBRBV78nZ933d8APHHkTQrD9Q==",
+			"requires": {
+				"@formatjs/ecma402-abstract": "1.11.8",
+				"@formatjs/fast-memoize": "1.2.4",
+				"@formatjs/icu-messageformat-parser": "2.1.4",
+				"tslib": "2.4.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
 		},
 		"ipaddr.js": {
 			"version": "2.0.1",
@@ -26321,14 +29071,42 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"react-autosize-textarea": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
-			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+		"react-aria": {
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.18.0.tgz",
+			"integrity": "sha512-sJwR6Utoq3zBg/sWG8Cu372zhxBiXQ31AZiy4thV6aa9N54yKZzM//JREPBH/RySQXFwkhZgakEh91RBOrfNrQ==",
 			"requires": {
-				"autosize": "^4.0.2",
-				"line-height": "^0.3.1",
-				"prop-types": "^15.5.6"
+				"@react-aria/breadcrumbs": "^3.3.0",
+				"@react-aria/button": "^3.6.0",
+				"@react-aria/calendar": "^3.0.1",
+				"@react-aria/checkbox": "^3.5.0",
+				"@react-aria/combobox": "^3.4.0",
+				"@react-aria/datepicker": "^3.1.0",
+				"@react-aria/dialog": "^3.3.0",
+				"@react-aria/focus": "^3.7.0",
+				"@react-aria/i18n": "^3.5.0",
+				"@react-aria/interactions": "^3.10.0",
+				"@react-aria/label": "^3.4.0",
+				"@react-aria/link": "^3.3.2",
+				"@react-aria/listbox": "^3.6.0",
+				"@react-aria/menu": "^3.6.0",
+				"@react-aria/meter": "^3.3.0",
+				"@react-aria/numberfield": "^3.3.0",
+				"@react-aria/overlays": "^3.10.0",
+				"@react-aria/progress": "^3.3.0",
+				"@react-aria/radio": "^3.3.0",
+				"@react-aria/searchfield": "^3.4.0",
+				"@react-aria/select": "^3.8.0",
+				"@react-aria/separator": "^3.2.2",
+				"@react-aria/slider": "^3.2.0",
+				"@react-aria/ssr": "^3.3.0",
+				"@react-aria/switch": "^3.2.2",
+				"@react-aria/table": "^3.4.0",
+				"@react-aria/tabs": "^3.3.0",
+				"@react-aria/textfield": "^3.7.0",
+				"@react-aria/tooltip": "^3.3.0",
+				"@react-aria/utils": "^3.13.2",
+				"@react-aria/visually-hidden": "^3.4.0"
 			}
 		},
 		"react-dom": {
@@ -26358,6 +29136,34 @@
 			"requires": {
 				"object-assign": "^4.1.1",
 				"react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"react-stately": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.16.0.tgz",
+			"integrity": "sha512-V+/sIjSt8xui0axxJ0DbiV3KiozCiynF1zCjroJBCaO9qUw/LL4yJoRK80YwQa6Ami9u7y+Ti7Q4Gu7XsMmZ6w==",
+			"requires": {
+				"@react-stately/calendar": "^3.0.1",
+				"@react-stately/checkbox": "^3.2.0",
+				"@react-stately/collections": "^3.4.2",
+				"@react-stately/combobox": "^3.2.0",
+				"@react-stately/data": "^3.6.0",
+				"@react-stately/datepicker": "^3.0.1",
+				"@react-stately/list": "^3.5.2",
+				"@react-stately/menu": "^3.4.0",
+				"@react-stately/numberfield": "^3.2.0",
+				"@react-stately/overlays": "^3.4.0",
+				"@react-stately/radio": "^3.5.0",
+				"@react-stately/searchfield": "^3.3.0",
+				"@react-stately/select": "^3.3.0",
+				"@react-stately/selection": "^3.10.2",
+				"@react-stately/slider": "^3.2.0",
+				"@react-stately/table": "^3.3.0",
+				"@react-stately/tabs": "^3.2.0",
+				"@react-stately/toggle": "^3.4.0",
+				"@react-stately/tooltip": "^3.2.0",
+				"@react-stately/tree": "^3.3.2",
+				"@react-types/shared": "^3.14.0"
 			}
 		},
 		"react-test-renderer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"@wordpress/env": "^4.9.0",
 				"@wordpress/i18n": "^4.14.0",
 				"@wordpress/scripts": "^23.6.0",
+				"autoprefixer": "^10.4.8",
 				"bulma": "^0.9.4",
 				"cssnano": "^5.1.12",
 				"cssnano-preset-default": "^5.2.12",
@@ -25,7 +26,8 @@
 				"fork-ts-checker-webpack-plugin": "^7.2.13",
 				"postcss-prefixer": "^2.1.3",
 				"prettier": "^2.7.1",
-				"typescript": "^4.7.4"
+				"typescript": "^4.7.4",
+				"webpack-remove-empty-scripts": "^0.8.1"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -4797,6 +4799,18 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/ansis": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ansis/-/ansis-1.4.0.tgz",
+			"integrity": "sha512-jaJCg2/68pwinZeW86YBSNv0kNPr3PSog/IqflOVCbqCedSCvrDCBUW1y4V9gcEUDNxrGtVLAkMIivvpsq1VwA==",
+			"engines": {
+				"node": ">=12.13"
+			},
+			"funding": {
+				"type": "patreon",
+				"url": "https://patreon.com/biodiscus"
+			}
+		},
 		"node_modules/anymatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -4955,9 +4969,9 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.7",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
-			"integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+			"version": "10.4.8",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
+			"integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4969,8 +4983,8 @@
 				}
 			],
 			"dependencies": {
-				"browserslist": "^4.20.3",
-				"caniuse-lite": "^1.0.30001335",
+				"browserslist": "^4.21.3",
+				"caniuse-lite": "^1.0.30001373",
 				"fraction.js": "^4.2.0",
 				"normalize-range": "^0.1.2",
 				"picocolors": "^1.0.0",
@@ -16332,6 +16346,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/webpack-remove-empty-scripts": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-0.8.1.tgz",
+			"integrity": "sha512-61hc2jfZOI6SAFDpIAQ910VFWc7ic+JWyjU0H/5A+1poKD9nOQRHnXaaixwsxXWI0+N1HUvmiREC3h9Dqn9xWw==",
+			"dependencies": {
+				"ansis": "^1.3.6"
+			},
+			"engines": {
+				"node": ">=12.14"
+			},
+			"funding": {
+				"type": "patreon",
+				"url": "https://patreon.com/biodiscus"
+			},
+			"peerDependencies": {
+				"webpack": ">=5.32.0"
+			}
+		},
 		"node_modules/webpack-sources": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -19983,6 +20015,11 @@
 				"color-convert": "^2.0.1"
 			}
 		},
+		"ansis": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ansis/-/ansis-1.4.0.tgz",
+			"integrity": "sha512-jaJCg2/68pwinZeW86YBSNv0kNPr3PSog/IqflOVCbqCedSCvrDCBUW1y4V9gcEUDNxrGtVLAkMIivvpsq1VwA=="
+		},
 		"anymatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -20096,12 +20133,12 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"autoprefixer": {
-			"version": "10.4.7",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.7.tgz",
-			"integrity": "sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==",
+			"version": "10.4.8",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.8.tgz",
+			"integrity": "sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==",
 			"requires": {
-				"browserslist": "^4.20.3",
-				"caniuse-lite": "^1.0.30001335",
+				"browserslist": "^4.21.3",
+				"caniuse-lite": "^1.0.30001373",
 				"fraction.js": "^4.2.0",
 				"normalize-range": "^0.1.2",
 				"picocolors": "^1.0.0",
@@ -28347,6 +28384,14 @@
 						"kind-of": "^6.0.2"
 					}
 				}
+			}
+		},
+		"webpack-remove-empty-scripts": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/webpack-remove-empty-scripts/-/webpack-remove-empty-scripts-0.8.1.tgz",
+			"integrity": "sha512-61hc2jfZOI6SAFDpIAQ910VFWc7ic+JWyjU0H/5A+1poKD9nOQRHnXaaixwsxXWI0+N1HUvmiREC3h9Dqn9xWw==",
+			"requires": {
+				"ansis": "^1.3.6"
 			}
 		},
 		"webpack-sources": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,23 @@
 			"version": "0.1.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
+				"@fullhuman/postcss-purgecss": "^4.1.3",
 				"@prettier/plugin-php": "^0.18.9",
 				"@types/wordpress__block-editor": "^7.0.0",
 				"@types/wordpress__data": "^6.0.1",
 				"@wordpress/element": "^4.12.0",
+				"@wordpress/env": "^4.9.0",
 				"@wordpress/i18n": "^4.14.0",
 				"@wordpress/scripts": "^23.6.0",
+				"bulma": "^0.9.4",
+				"cssnano": "^5.1.12",
+				"cssnano-preset-default": "^5.2.12",
 				"eslint": "^8.21.0",
 				"eslint-plugin-prettier": "^4.2.1",
 				"fork-ts-checker-webpack-plugin": "^7.2.13",
+				"postcss-prefixer": "^2.1.3",
 				"prettier": "^2.7.1",
 				"typescript": "^4.7.4"
-			},
-			"devDependencies": {
-				"@wordpress/env": "^4.9.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1901,6 +1904,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@fullhuman/postcss-purgecss": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.1.3.tgz",
+			"integrity": "sha512-jqcsyfvq09VOsMXxJMPLRF6Fhg/NNltzWKnC9qtzva+QKTxerCO4esG6je7hbnmkpZtaDyPTwMBj9bzfWorsrw==",
+			"dependencies": {
+				"purgecss": "^4.1.3"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.0"
+			}
+		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -2355,7 +2369,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
 			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-			"dev": true,
 			"dependencies": {
 				"debug": "^4.1.1"
 			}
@@ -2363,8 +2376,7 @@
 		"node_modules/@kwsites/promise-deferred": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
-			"dev": true
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
 		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.4",
@@ -2492,7 +2504,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
 			"integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -2761,7 +2772,6 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
 			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-			"dev": true,
 			"dependencies": {
 				"defer-to-connect": "^2.0.0"
 			},
@@ -2870,7 +2880,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
 			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
-			"dev": true,
 			"dependencies": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -2967,8 +2976,7 @@
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
-			"dev": true
+			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
 		},
 		"node_modules/@types/http-proxy": {
 			"version": "1.17.9",
@@ -3002,8 +3010,7 @@
 		"node_modules/@types/json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==",
-			"dev": true
+			"integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.11",
@@ -3019,7 +3026,6 @@
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
 			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -3096,7 +3102,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
 			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -4185,7 +4190,6 @@
 			"version": "4.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.9.0.tgz",
 			"integrity": "sha512-C2g5aOYxl1Bd9lypvEMjXZ1s1Gx/JHpFWuPlCAI8gAzwzB9jCIZkqpU85GsGScpZLAANS/N7wF3LMY68UkN9fQ==",
-			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
@@ -4208,7 +4212,6 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.0.0"
 			}
@@ -4217,7 +4220,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
 			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-			"dev": true,
 			"dependencies": {
 				"concat-stream": "^1.6.2",
 				"debug": "^2.6.9",
@@ -4231,14 +4233,12 @@
 		"node_modules/@wordpress/env/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 		},
 		"node_modules/@wordpress/env/node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
 			},
@@ -4253,7 +4253,6 @@
 			"version": "17.5.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
 			"integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
-			"dev": true,
 			"dependencies": {
 				"cliui": "^7.0.2",
 				"escalade": "^3.1.1",
@@ -4271,7 +4270,6 @@
 			"version": "21.0.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
 			"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-			"dev": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -5402,6 +5400,11 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
+		"node_modules/bulma": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz",
+			"integrity": "sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ=="
+		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -5414,7 +5417,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
 			"integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
-			"dev": true,
 			"dependencies": {
 				"@types/keyv": "^3.1.1",
 				"keyv": "^4.0.0"
@@ -5427,7 +5429,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
 			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
-			"dev": true,
 			"dependencies": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -5445,7 +5446,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -5563,8 +5563,7 @@
 		"node_modules/chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
 		"node_modules/check-node-version": {
 			"version": "4.2.1",
@@ -5712,7 +5711,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
 			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
 			"dependencies": {
 				"restore-cursor": "^3.1.0"
 			},
@@ -5724,7 +5722,6 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
 			"integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			},
@@ -5736,7 +5733,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
 			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 10"
 			}
@@ -5755,7 +5751,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
 			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.8"
 			}
@@ -5790,7 +5785,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
 			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-			"dev": true,
 			"dependencies": {
 				"mimic-response": "^1.0.0"
 			},
@@ -5802,7 +5796,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
 			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -5888,7 +5881,6 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
 			"integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
-			"dev": true,
 			"dependencies": {
 				"@types/json-buffer": "~3.0.0",
 				"json-buffer": "~3.0.1"
@@ -5957,7 +5949,6 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"engines": [
 				"node >= 0.8"
 			],
@@ -5972,7 +5963,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -5987,7 +5977,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -6062,8 +6051,7 @@
 		"node_modules/copy-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
-			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
-			"dev": true
+			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw=="
 		},
 		"node_modules/copy-webpack-plugin": {
 			"version": "10.2.4",
@@ -6346,6 +6334,15 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css-selector-tokenizer": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+			"integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"fastparse": "^1.1.2"
+			}
+		},
 		"node_modules/css-tree": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
@@ -6581,7 +6578,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
 			"integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
-			"dev": true,
 			"dependencies": {
 				"mimic-response": "^2.0.0"
 			},
@@ -6630,7 +6626,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
-			"dev": true,
 			"dependencies": {
 				"clone": "^1.0.2"
 			}
@@ -6639,7 +6634,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
 			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -6805,7 +6799,6 @@
 			"version": "0.22.2",
 			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
 			"integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-			"dev": true,
 			"engines": {
 				"node": ">= 6.0.0"
 			}
@@ -6919,8 +6912,7 @@
 		"node_modules/duplexer3": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
-			"integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
-			"dev": true
+			"integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="
 		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
@@ -8111,7 +8103,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
 			"dependencies": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -8125,7 +8116,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			},
@@ -8220,6 +8210,11 @@
 				"node": ">= 4.9.1"
 			}
 		},
+		"node_modules/fastparse": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
+		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -8259,7 +8254,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
 			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-			"dev": true,
 			"dependencies": {
 				"escape-string-regexp": "^1.0.5"
 			},
@@ -8274,7 +8268,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -8872,7 +8865,6 @@
 			"version": "10.7.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
 			"integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
-			"dev": true,
 			"dependencies": {
 				"@sindresorhus/is": "^2.0.0",
 				"@szmarczak/http-timer": "^4.0.0",
@@ -8901,7 +8893,6 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
 			"dependencies": {
 				"pump": "^3.0.0"
 			},
@@ -8916,7 +8907,6 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
 			"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -8970,6 +8960,25 @@
 			},
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/has-ansi/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/has-bigints": {
@@ -9138,8 +9147,7 @@
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-			"dev": true
+			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
 		},
 		"node_modules/http-deceiver": {
 			"version": "1.2.7",
@@ -9388,7 +9396,6 @@
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
 			"integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-			"dev": true,
 			"dependencies": {
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.1.0",
@@ -9412,7 +9419,6 @@
 			"version": "6.6.7",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
 			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-			"dev": true,
 			"dependencies": {
 				"tslib": "^1.9.0"
 			},
@@ -9601,7 +9607,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
 			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -10534,6 +10539,11 @@
 				"@sideway/pinpoint": "^2.0.0"
 			}
 		},
+		"node_modules/js-base64": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+			"integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10623,8 +10633,7 @@
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -10697,7 +10706,6 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
 			"integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
-			"dev": true,
 			"dependencies": {
 				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
@@ -10923,7 +10931,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
 			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -11282,7 +11289,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
 			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -11439,7 +11445,6 @@
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
 			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.6"
 			},
@@ -11485,8 +11490,7 @@
 		"node_modules/mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.4",
@@ -11974,7 +11978,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
 			"integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
-			"dev": true,
 			"dependencies": {
 				"chalk": "^3.0.0",
 				"cli-cursor": "^3.1.0",
@@ -11996,7 +11999,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
 			"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -12009,7 +12011,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -12017,14 +12018,12 @@
 		"node_modules/ora/node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 		},
 		"node_modules/ora/node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
@@ -12033,7 +12032,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -12042,7 +12040,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
 			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-			"dev": true,
 			"dependencies": {
 				"chalk": "^2.4.2"
 			},
@@ -12054,7 +12051,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -12066,7 +12062,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -12080,7 +12075,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -12100,7 +12094,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12109,7 +12102,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
 			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -12126,7 +12118,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
 			"integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-			"dev": true,
 			"dependencies": {
 				"p-timeout": "^3.1.0"
 			},
@@ -12141,7 +12132,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -12198,7 +12188,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
 			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-			"dev": true,
 			"dependencies": {
 				"p-finally": "^1.0.0"
 			},
@@ -12921,6 +12910,120 @@
 				"postcss": "^8.2.15"
 			}
 		},
+		"node_modules/postcss-prefixer": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-prefixer/-/postcss-prefixer-2.1.3.tgz",
+			"integrity": "sha512-1ixOH5d9bt/YXw3iJ8FmBAqdviVTj1pdYSDvUDz4dY95tX/hKDXMa34YkQvXGRKkAMoehUd5pKVaF+D1qTbQOg==",
+			"dependencies": {
+				"css-selector-tokenizer": "^0.7.2",
+				"postcss": "^5.2.18"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			},
+			"peerDependencies": {
+				"postcss": ">= 5.0.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+			"dependencies": {
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/chalk/node_modules/supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/has-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+			"integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/postcss": {
+			"version": "5.2.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+			"dependencies": {
+				"chalk": "^1.1.3",
+				"js-base64": "^2.1.9",
+				"source-map": "^0.5.6",
+				"supports-color": "^3.2.3"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+			"dependencies": {
+				"ansi-regex": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/postcss-prefixer/node_modules/supports-color": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+			"integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+			"dependencies": {
+				"has-flag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/postcss-reduce-initial": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
@@ -13234,6 +13337,28 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/purgecss": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.1.3.tgz",
+			"integrity": "sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==",
+			"dependencies": {
+				"commander": "^8.0.0",
+				"glob": "^7.1.7",
+				"postcss": "^8.3.5",
+				"postcss-selector-parser": "^6.0.6"
+			},
+			"bin": {
+				"purgecss": "bin/purgecss.js"
+			}
+		},
+		"node_modules/purgecss/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/qs": {
@@ -13787,7 +13912,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
 			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-			"dev": true,
 			"dependencies": {
 				"lowercase-keys": "^2.0.0"
 			},
@@ -13799,7 +13923,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
 			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
 			"dependencies": {
 				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
@@ -13857,7 +13980,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
 			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -14255,7 +14377,6 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.10.0.tgz",
 			"integrity": "sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==",
-			"dev": true,
 			"dependencies": {
 				"@kwsites/file-exists": "^1.1.1",
 				"@kwsites/promise-deferred": "^1.1.1",
@@ -15269,7 +15390,6 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"dependencies": {
 				"os-tmpdir": "~1.0.2"
 			},
@@ -15294,7 +15414,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
 			"integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -15479,8 +15598,7 @@
 		"node_modules/typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-			"dev": true
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
 		},
 		"node_modules/typedarray-to-buffer": {
 			"version": "3.1.5",
@@ -15766,7 +15884,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-			"dev": true,
 			"dependencies": {
 				"defaults": "^1.0.3"
 			}
@@ -17734,6 +17851,14 @@
 				}
 			}
 		},
+		"@fullhuman/postcss-purgecss": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.1.3.tgz",
+			"integrity": "sha512-jqcsyfvq09VOsMXxJMPLRF6Fhg/NNltzWKnC9qtzva+QKTxerCO4esG6je7hbnmkpZtaDyPTwMBj9bzfWorsrw==",
+			"requires": {
+				"purgecss": "^4.1.3"
+			}
+		},
 		"@hapi/hoek": {
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -18093,7 +18218,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
 			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-			"dev": true,
 			"requires": {
 				"debug": "^4.1.1"
 			}
@@ -18101,8 +18225,7 @@
 		"@kwsites/promise-deferred": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
-			"dev": true
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
 		},
 		"@leichtgewicht/ip-codec": {
 			"version": "2.0.4",
@@ -18184,8 +18307,7 @@
 		"@sindresorhus/is": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
-			"integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
-			"dev": true
+			"integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.3",
@@ -18325,7 +18447,6 @@
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
 			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-			"dev": true,
 			"requires": {
 				"defer-to-connect": "^2.0.0"
 			}
@@ -18425,7 +18546,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
 			"integrity": "sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==",
-			"dev": true,
 			"requires": {
 				"@types/http-cache-semantics": "*",
 				"@types/keyv": "*",
@@ -18522,8 +18642,7 @@
 		"@types/http-cache-semantics": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
-			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
-			"dev": true
+			"integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
 		},
 		"@types/http-proxy": {
 			"version": "1.17.9",
@@ -18557,8 +18676,7 @@
 		"@types/json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@types/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==",
-			"dev": true
+			"integrity": "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ=="
 		},
 		"@types/json-schema": {
 			"version": "7.0.11",
@@ -18574,7 +18692,6 @@
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
 			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -18651,7 +18768,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
 			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-			"dev": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -19441,7 +19557,6 @@
 			"version": "4.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-4.9.0.tgz",
 			"integrity": "sha512-C2g5aOYxl1Bd9lypvEMjXZ1s1Gx/JHpFWuPlCAI8gAzwzB9jCIZkqpU85GsGScpZLAANS/N7wF3LMY68UkN9fQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
 				"copy-dir": "^1.3.0",
@@ -19461,7 +19576,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -19470,7 +19584,6 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
 					"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
-					"dev": true,
 					"requires": {
 						"concat-stream": "^1.6.2",
 						"debug": "^2.6.9",
@@ -19481,14 +19594,12 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-					"dev": true
+					"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
 				},
 				"rimraf": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -19497,7 +19608,6 @@
 					"version": "17.5.1",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
 					"integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
-					"dev": true,
 					"requires": {
 						"cliui": "^7.0.2",
 						"escalade": "^3.1.1",
@@ -19511,8 +19621,7 @@
 				"yargs-parser": {
 					"version": "21.0.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
-					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-					"dev": true
+					"integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
 				}
 			}
 		},
@@ -20304,6 +20413,11 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
+		"bulma": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz",
+			"integrity": "sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ=="
+		},
 		"bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -20313,7 +20427,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
 			"integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
-			"dev": true,
 			"requires": {
 				"@types/keyv": "^3.1.1",
 				"keyv": "^4.0.0"
@@ -20323,7 +20436,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
 			"integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
-			"dev": true,
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -20338,7 +20450,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -20414,8 +20525,7 @@
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-			"dev": true
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
 		"check-node-version": {
 			"version": "4.2.1",
@@ -20526,7 +20636,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
 			"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-			"dev": true,
 			"requires": {
 				"restore-cursor": "^3.1.0"
 			}
@@ -20534,14 +20643,12 @@
 		"cli-spinners": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-			"integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
-			"dev": true
+			"integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw=="
 		},
 		"cli-width": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-			"dev": true
+			"integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
 		},
 		"cliui": {
 			"version": "7.0.4",
@@ -20556,8 +20663,7 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-			"dev": true
+			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
 		},
 		"clone-deep": {
 			"version": "0.2.4",
@@ -20583,7 +20689,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
 			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			},
@@ -20591,8 +20696,7 @@
 				"mimic-response": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-					"dev": true
+					"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 				}
 			}
 		},
@@ -20661,7 +20765,6 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
 			"integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
-			"dev": true,
 			"requires": {
 				"@types/json-buffer": "~3.0.0",
 				"json-buffer": "~3.0.1"
@@ -20723,7 +20826,6 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -20735,7 +20837,6 @@
 					"version": "2.3.7",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -20750,7 +20851,6 @@
 					"version": "1.1.1",
 					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
 					}
@@ -20803,8 +20903,7 @@
 		"copy-dir": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
-			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
-			"dev": true
+			"integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw=="
 		},
 		"copy-webpack-plugin": {
 			"version": "10.2.4",
@@ -21001,6 +21100,15 @@
 				"nth-check": "^2.0.1"
 			}
 		},
+		"css-selector-tokenizer": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz",
+			"integrity": "sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==",
+			"requires": {
+				"cssesc": "^3.0.0",
+				"fastparse": "^1.1.2"
+			}
+		},
 		"css-tree": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
@@ -21174,7 +21282,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
 			"integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^2.0.0"
 			}
@@ -21211,7 +21318,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
-			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -21219,8 +21325,7 @@
 		"defer-to-connect": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-			"dev": true
+			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
 		},
 		"define-lazy-prop": {
 			"version": "2.0.0",
@@ -21343,8 +21448,7 @@
 		"docker-compose": {
 			"version": "0.22.2",
 			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-			"integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
-			"dev": true
+			"integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg=="
 		},
 		"doctrine": {
 			"version": "3.0.0",
@@ -21429,8 +21533,7 @@
 		"duplexer3": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
-			"integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
-			"dev": true
+			"integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="
 		},
 		"ee-first": {
 			"version": "1.1.1",
@@ -22311,7 +22414,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
 			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -22322,7 +22424,6 @@
 					"version": "0.4.24",
 					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
 					}
@@ -22397,6 +22498,11 @@
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
 			"integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA=="
 		},
+		"fastparse": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
+		},
 		"fastq": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -22433,7 +22539,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
 			"integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
 			},
@@ -22441,8 +22546,7 @@
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 				}
 			}
 		},
@@ -22861,7 +22965,6 @@
 			"version": "10.7.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
 			"integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
-			"dev": true,
 			"requires": {
 				"@sindresorhus/is": "^2.0.0",
 				"@szmarczak/http-timer": "^4.0.0",
@@ -22884,7 +22987,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -22892,8 +22994,7 @@
 				"type-fest": {
 					"version": "0.10.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
-					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
-					"dev": true
+					"integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw=="
 				}
 			}
 		},
@@ -22931,6 +23032,21 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"requires": {
 				"function-bind": "^1.1.1"
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+				}
 			}
 		},
 		"has-bigints": {
@@ -23058,8 +23174,7 @@
 		"http-cache-semantics": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-			"dev": true
+			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
 		},
 		"http-deceiver": {
 			"version": "1.2.7",
@@ -23229,7 +23344,6 @@
 			"version": "7.3.3",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
 			"integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
-			"dev": true,
 			"requires": {
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.1.0",
@@ -23250,7 +23364,6 @@
 					"version": "6.6.7",
 					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
 					"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-					"dev": true,
 					"requires": {
 						"tslib": "^1.9.0"
 					}
@@ -23374,8 +23487,7 @@
 		"is-interactive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-			"dev": true
+			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
 		},
 		"is-negative-zero": {
 			"version": "2.0.2",
@@ -24071,6 +24183,11 @@
 				"@sideway/pinpoint": "^2.0.0"
 			}
 		},
+		"js-base64": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
+			"integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -24139,8 +24256,7 @@
 		"json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-			"dev": true
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -24201,7 +24317,6 @@
 			"version": "4.3.3",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
 			"integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
-			"dev": true,
 			"requires": {
 				"compress-brotli": "^1.3.8",
 				"json-buffer": "3.0.1"
@@ -24381,8 +24496,7 @@
 		"lowercase-keys": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-			"dev": true
+			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
 		},
 		"lru-cache": {
 			"version": "4.1.5",
@@ -24648,8 +24762,7 @@
 		"mimic-response": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-			"dev": true
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
 		},
 		"min-indent": {
 			"version": "1.0.1",
@@ -24761,7 +24874,6 @@
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
 			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.6"
 			}
@@ -24798,8 +24910,7 @@
 		"mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true
+			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
 		},
 		"nanoid": {
 			"version": "3.3.4",
@@ -25156,7 +25267,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
 			"integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
-			"dev": true,
 			"requires": {
 				"chalk": "^3.0.0",
 				"cli-cursor": "^3.1.0",
@@ -25172,7 +25282,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
 					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
@@ -25182,7 +25291,6 @@
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
 					}
@@ -25190,26 +25298,22 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-					"dev": true
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-					"dev": true
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-					"dev": true
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
 				},
 				"log-symbols": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
 					"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
-					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2"
 					},
@@ -25218,7 +25322,6 @@
 							"version": "3.2.1",
 							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 							"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-							"dev": true,
 							"requires": {
 								"color-convert": "^1.9.0"
 							}
@@ -25227,7 +25330,6 @@
 							"version": "2.4.2",
 							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-							"dev": true,
 							"requires": {
 								"ansi-styles": "^3.2.1",
 								"escape-string-regexp": "^1.0.5",
@@ -25238,7 +25340,6 @@
 							"version": "5.5.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
 							"requires": {
 								"has-flag": "^3.0.0"
 							}
@@ -25255,14 +25356,12 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-			"dev": true
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
 		},
 		"p-cancelable": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-			"dev": true
+			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="
 		},
 		"p-defer": {
 			"version": "1.0.0",
@@ -25273,7 +25372,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
 			"integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-			"dev": true,
 			"requires": {
 				"p-timeout": "^3.1.0"
 			}
@@ -25281,8 +25379,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-			"dev": true
+			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
 		},
 		"p-limit": {
 			"version": "3.1.0",
@@ -25318,7 +25415,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
 			"integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-			"dev": true,
 			"requires": {
 				"p-finally": "^1.0.0"
 			}
@@ -25778,6 +25874,88 @@
 				"postcss-value-parser": "^4.2.0"
 			}
 		},
+		"postcss-prefixer": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/postcss-prefixer/-/postcss-prefixer-2.1.3.tgz",
+			"integrity": "sha512-1ixOH5d9bt/YXw3iJ8FmBAqdviVTj1pdYSDvUDz4dY95tX/hKDXMa34YkQvXGRKkAMoehUd5pKVaF+D1qTbQOg==",
+			"requires": {
+				"css-selector-tokenizer": "^0.7.2",
+				"postcss": "^5.2.18"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+							"integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+						}
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA=="
+				},
+				"postcss": {
+					"version": "5.2.18",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+					"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+					"requires": {
+						"chalk": "^1.1.3",
+						"js-base64": "^2.1.9",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==",
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				}
+			}
+		},
 		"postcss-reduce-initial": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
@@ -25991,6 +26169,24 @@
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
 					"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
 					"requires": {}
+				}
+			}
+		},
+		"purgecss": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.1.3.tgz",
+			"integrity": "sha512-99cKy4s+VZoXnPxaoM23e5ABcP851nC2y2GROkkjS8eJaJtlciGavd7iYAw2V84WeBqggZ12l8ef44G99HmTaw==",
+			"requires": {
+				"commander": "^8.0.0",
+				"glob": "^7.1.7",
+				"postcss": "^8.3.5",
+				"postcss-selector-parser": "^6.0.6"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "8.3.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+					"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
 				}
 			}
 		},
@@ -26397,7 +26593,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
 			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-			"dev": true,
 			"requires": {
 				"lowercase-keys": "^2.0.0"
 			}
@@ -26406,7 +26601,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
 			"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-			"dev": true,
 			"requires": {
 				"onetime": "^5.1.0",
 				"signal-exit": "^3.0.2"
@@ -26447,8 +26641,7 @@
 		"run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-			"dev": true
+			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
 		},
 		"run-con": {
 			"version": "1.2.11",
@@ -26749,7 +26942,6 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.10.0.tgz",
 			"integrity": "sha512-2w35xrS5rVtAW0g67LqtxCZN5cdddz/woQRfS0OJXaljXEoTychZ4jnE+CQgra/wX4ZvHeiChTUMenCwfIYEYw==",
-			"dev": true,
 			"requires": {
 				"@kwsites/file-exists": "^1.1.1",
 				"@kwsites/promise-deferred": "^1.1.1",
@@ -27511,7 +27703,6 @@
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"
 			}
@@ -27529,8 +27720,7 @@
 		"to-readable-stream": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
-			"integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
-			"dev": true
+			"integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w=="
 		},
 		"to-regex-range": {
 			"version": "5.0.1",
@@ -27662,8 +27852,7 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-			"dev": true
+			"integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
 		},
 		"typedarray-to-buffer": {
 			"version": "3.1.5",
@@ -27865,7 +28054,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@wordpress/env": "^4.9.0",
 		"@wordpress/i18n": "^4.14.0",
 		"@wordpress/scripts": "^23.6.0",
+		"autoprefixer": "^10.4.8",
 		"bulma": "^0.9.4",
 		"cssnano": "^5.1.12",
 		"cssnano-preset-default": "^5.2.12",
@@ -33,6 +34,7 @@
 		"fork-ts-checker-webpack-plugin": "^7.2.13",
 		"postcss-prefixer": "^2.1.3",
 		"prettier": "^2.7.1",
-		"typescript": "^4.7.4"
+		"typescript": "^4.7.4",
+		"webpack-remove-empty-scripts": "^0.8.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -17,19 +17,22 @@
 		"start": "wp-scripts start"
 	},
 	"dependencies": {
+		"@fullhuman/postcss-purgecss": "^4.1.3",
 		"@prettier/plugin-php": "^0.18.9",
 		"@types/wordpress__block-editor": "^7.0.0",
 		"@types/wordpress__data": "^6.0.1",
 		"@wordpress/element": "^4.12.0",
+		"@wordpress/env": "^4.9.0",
 		"@wordpress/i18n": "^4.14.0",
 		"@wordpress/scripts": "^23.6.0",
+		"bulma": "^0.9.4",
+		"cssnano": "^5.1.12",
+		"cssnano-preset-default": "^5.2.12",
 		"eslint": "^8.21.0",
 		"eslint-plugin-prettier": "^4.2.1",
 		"fork-ts-checker-webpack-plugin": "^7.2.13",
+		"postcss-prefixer": "^2.1.3",
 		"prettier": "^2.7.1",
 		"typescript": "^4.7.4"
-	},
-	"devDependencies": {
-		"@wordpress/env": "^4.9.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
 		"@fullhuman/postcss-purgecss": "^4.1.3",
 		"@prettier/plugin-php": "^0.18.9",
 		"@types/wordpress__block-editor": "^7.0.0",
-		"@types/wordpress__data": "^6.0.1",
 		"@wordpress/element": "^4.12.0",
 		"@wordpress/env": "^4.9.0",
 		"@wordpress/i18n": "^4.14.0",
 		"@wordpress/scripts": "^23.6.0",
 		"autoprefixer": "^10.4.8",
 		"bulma": "^0.9.4",
+		"classnames": "^2.3.1",
 		"cssnano": "^5.1.12",
 		"cssnano-preset-default": "^5.2.12",
 		"eslint": "^8.21.0",
@@ -34,6 +34,8 @@
 		"fork-ts-checker-webpack-plugin": "^7.2.13",
 		"postcss-prefixer": "^2.1.3",
 		"prettier": "^2.7.1",
+		"react-aria": "^3.18.0",
+		"react-stately": "^3.16.0",
 		"typescript": "^4.7.4",
 		"webpack-remove-empty-scripts": "^0.8.1"
 	}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,31 @@
+const purgecss = require('@fullhuman/postcss-purgecss')
+const cssnano = require('cssnano')
+const autoprefixer = require('autoprefixer')
+const prefixer = require('postcss-prefixer')
+
+const maybePurgecss =
+	process.env.NODE_ENV === 'production'
+		? purgecss({
+				content: ['build/**/*.html', 'build/**/*.js'],
+		  })
+		: null
+
+const cssnanoInstance = cssnano({
+	preset: [
+		'default',
+		{
+			discardComments: {
+				removeAll: true,
+			},
+		},
+	],
+})
+
+module.exports = {
+	plugins: [
+		autoprefixer({ grid: true }),
+		prefixer({ prefix: 'inseri-' }),
+		cssnanoInstance,
+		maybePurgecss,
+	],
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,10 +3,13 @@ const cssnano = require('cssnano')
 const autoprefixer = require('autoprefixer')
 const prefixer = require('postcss-prefixer')
 
+const ignoreClasses = [/wp-block-*/]
+
 const maybePurgecss =
 	process.env.NODE_ENV === 'production'
 		? purgecss({
 				content: ['build/**/*.html', 'build/**/*.js'],
+				safelist: ignoreClasses,
 		  })
 		: null
 
@@ -24,7 +27,7 @@ const cssnanoInstance = cssnano({
 module.exports = {
 	plugins: [
 		autoprefixer({ grid: true }),
-		prefixer({ prefix: 'inseri-' }),
+		prefixer({ prefix: 'inseri-', ignore: ignoreClasses }),
 		cssnanoInstance,
 		maybePurgecss,
 	],

--- a/src/blocks/core/block.json
+++ b/src/blocks/core/block.json
@@ -14,5 +14,5 @@
 	"textdomain": "inseri-core",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"style": "file:./style-index.css"
+	"style": ["file:./style-index.css", "file:../../global.css"]
 }

--- a/src/blocks/core/edit.tsx
+++ b/src/blocks/core/edit.tsx
@@ -1,10 +1,19 @@
 import { __ } from '@wordpress/i18n'
 import { useBlockProps } from '@wordpress/block-editor'
 import './editor.scss'
+import { Button } from '../../component-library/button'
 
 export default function Edit() {
 	return (
 		<p {...useBlockProps()}>
+			<Button
+				onPress={() => {
+					console.log('Button pressed') // eslint-disable-line no-console
+				}}
+				className={'inseri-is-danger'}
+			>
+				A11y click
+			</Button>
 			{__('Inseri Core – hello from the editor!', 'core')}
 		</p>
 	)

--- a/src/blocks/core/index.tsx
+++ b/src/blocks/core/index.tsx
@@ -3,13 +3,11 @@ import './style.scss'
 import json from './block.json'
 import edit from './edit'
 import save from './save'
-import type { BlockIcon } from 'wordpress__blocks'
 
-const { name, icon, ...settings } = json
+const { name, ...settings } = json as any
 
 registerBlockType<any>(name, {
 	...settings,
-	icon: icon as BlockIcon,
 	edit,
 	save,
 })

--- a/src/blocks/core/style.scss
+++ b/src/blocks/core/style.scss
@@ -1,5 +1,6 @@
+@charset "utf-8";
+@import '~bulma/bulma';
+
 .wp-block-inseri-core {
-	background-color: #21759b;
-	color: #fff;
 	padding: 2px;
 }

--- a/src/blocks/core/style.scss
+++ b/src/blocks/core/style.scss
@@ -1,6 +1,3 @@
-@charset "utf-8";
-@import '~bulma/bulma';
-
 .wp-block-inseri-core {
 	padding: 2px;
 }

--- a/src/component-library/button.tsx
+++ b/src/component-library/button.tsx
@@ -1,0 +1,24 @@
+import { useButton } from 'react-aria'
+import type { AriaButtonProps } from 'react-aria'
+import { useRef } from '@wordpress/element'
+import classnames from 'classnames'
+
+interface OwnProps {
+	className?: string
+}
+
+export const Button: React.FC<AriaButtonProps & OwnProps> = (props) => {
+	const ref = useRef<HTMLButtonElement>(null)
+	const { buttonProps } = useButton(props, ref)
+	const { children, className } = props
+
+	return (
+		<button
+			{...buttonProps}
+			className={classnames(className, 'inseri-button')}
+			ref={ref}
+		>
+			{children}
+		</button>
+	)
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -1,0 +1,2 @@
+@charset "utf-8";
+@import '~bulma/bulma';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,21 +1,28 @@
 const defaultConfig = require('@wordpress/scripts/config/webpack.config')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
+const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts')
 const fs = require('fs')
 
 const tsChecker = new ForkTsCheckerWebpackPlugin({
 	typescript: { diagnosticOptions: { semantic: true, syntactic: true } },
 })
 
+const initialEntrypoints = { global: './src/global.scss' }
+
 const blockEntrypoints = fs.readdirSync('./src/blocks').reduce(
 	(accumulator, item) => ({
 		...accumulator,
 		[`blocks/${item}/index`]: `./src/blocks/${item}`,
 	}),
-	{}
+	initialEntrypoints
 )
 
 module.exports = {
 	...defaultConfig,
 	entry: { ...blockEntrypoints },
-	plugins: [...defaultConfig.plugins, tsChecker],
+	plugins: [
+		...defaultConfig.plugins,
+		tsChecker,
+		new RemoveEmptyScriptsPlugin(),
+	],
 }


### PR DESCRIPTION
## Insights
- [Headless components in React](https://medium.com/@nirbenyair/headless-components-in-react-and-why-i-stopped-using-ui-libraries-a8208197c268)
- [Awesome React Headless Components](https://github.com/jxom/awesome-react-headless-components)
- Known issue:  primary/accent color cannot be referenced across different themes  ([see wp issue](https://github.com/WordPress/gutenberg/issues/29568))
- A small set of classes are provided for individual element.  These classes will be overwritten on theme switch ([more info](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#element-styles))
- we cannot use React Hooks inside save function ([see wp issue](https://github.com/WordPress/gutenberg/issues/43201))
- we can only rely on the following css variables because they are consistently used across themes:
```
 --wp--preset--font-size--small
 --wp--preset--font-size--medium
 --wp--preset--font-size--large
 --wp--preset--font-size--x-large
```

## Components Candidates 
- [WP Components](https://developer.wordpress.org/block-editor/reference-guides/components/)
     - they're already styled
     - limited extensibility
- [Material UI](https://mui.com/)
    - variant MUI is stable, but components are pre-styled
    - variant MUI Base is unstyled as desired. However, it is currently in alpha.
- [RadixUI](https://www.radix-ui.com/) 
    - unstyled
- [React Aria by Adobe](https://react-spectrum.adobe.com/react-aria)
    - provides only accessibility and behavior
    - requires also `@react-stately`

## Styling Candidates
- [stitches](https://stitches.dev/): 
    - requires react runtime
    - especially hard with SSR, we cannot control SSR from WP
- [styled-components](https://styled-components.com/):
    - same problems as with stitches
- [JSS](https://cssinjs.org/?v=v10.9.2)
    - same problems as with stitches
- [tailwindcss](https://tailwindcss.com/)
    - requires advanced css background
- [Bulma](https://bulma.io/)
    - bulma classes has no prefix. therefore, these classes collides with theme classes
    - with a postcss plugin, own classes and bulma classes can be prefixed
    -  has modifier classes such as `has-text-black`
- [Adobe Spectrum CSS](https://opensource.adobe.com/spectrum-css)
    - too much of their corporate design  
- [Github Primer](https://primer.style/css/)
    - too much of their corporate design  

## Conclusion
- bulma will be used for styling because it is modular, flexible and simple to use
- react-aria is chosen over radix ui because react-aria provides atomic tools to build complex components, whereas radix ui only offers limited components