### PR TITLE
Fix rule to match yml in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[{*.yml}]
+[*.yml]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
The configuration for indentation in YAML will be applied to all `*.yml` files by editorconfig.